### PR TITLE
Fix for eof check

### DIFF
--- a/src/select_file.c
+++ b/src/select_file.c
@@ -128,7 +128,7 @@ unsigned char select_file_display(void)
   for (i = 0; i < ENTRIES_PER_PAGE; i++)
   {
     e = io_read_directory(DIR_MAX_LEN, 0);
-    if (e[2] == 0x7F)
+    if (e[1] == 0x7F)
     {
       dir_eof = true;
       break;
@@ -143,7 +143,7 @@ unsigned char select_file_display(void)
 
   // Do one more read to check EOF
   e = io_read_directory(DIR_MAX_LEN, 0);
-  if (e[2] == 0x7F)
+  if (e[1] == 0x7F)
     dir_eof = true;
 
   io_close_directory();


### PR DESCRIPTION
Found this while working on the Atari implementation - since I don't have an Adam I don't know what effect it will have there, so definitely check it over for me.

According to the [Wiki](https://github.com/FujiNetWIFI/fujinet-platformio/wiki/SIO-Command-%24F6-Read-Directory), the 1st two bytes will be 0x7F if we've reached the end of the directory. This was checking e[2] (3rd byte). This definitely was breaking the Atari implementation I'm working on - not sure if/why it worked on the Adam?