### PR TITLE
Fix for issue #23

### DIFF
--- a/src/select_file.c
+++ b/src/select_file.c
@@ -230,7 +230,6 @@ void select_prev_page(void)
 
 void select_file_filter(void)
 {
-  memset(filter, 0, 32);
   screen_select_file_filter();
   input_line_filter(filter);
   dir_eof = quick_boot = false;


### PR DESCRIPTION
Remove "memset" from select_file_filter() so that the filter isn't wiped out each time you want to edit the filter (in case you decide you didn't want to change it afterall, for example)

Also, for the Atari, this fixes the issue of going from a longer filter (ex: 'auto*.atr' to a smaller filter 'a*.atr' leaving text on the screen from the longer filter, since now when you go to edit the filter the cursor will be at the END of the line rather than the beginning, which means you have to delete the characters to make the filter shorter anyway, which cleans up the screen)