### PR TITLE
Fix corrupted 'path' variable when going up a folder level

### DIFF
--- a/src/select_file.c
+++ b/src/select_file.c
@@ -274,6 +274,7 @@ void select_file_advance(void)
 
 void select_file_devance(void)
 {
+  int i;
   char *p = strrchr(path, '/'); // find end of directory string (last /)
 
   bar_clear(false);
@@ -284,6 +285,11 @@ void select_file_devance(void)
   p++;
 
   *p = 0; // truncate string.
+
+  for ( i = strlen (path); i < 224; i++ )
+  {
+    path[i] = 0;
+  }
 
   pos = 0;
   dir_eof = quick_boot = false;


### PR DESCRIPTION
When devancing/going back/up a folder level, the "path" variable wasn't getting fully "nulled out" - it was just getting a null put in the string at the end of the new path, but the text from the previous path was still present in the string after the null. The FujiNet interprets text after the null as a "filter" for the open directory function. 