### PR TITLE
New Makefile.apple2gs plus changes targeted at building with GoldenGate and ORCA/C

### DIFF
--- a/Makefile.apple2cda
+++ b/Makefile.apple2cda
@@ -1,0 +1,355 @@
+###############################################################################
+### Generic Makefile for cc65 projects - full version with abstract options ###
+### V1.3.0(w) 2010 - 2013 Oliver Schmidt & Patryk "Silver Dream !" Łogiewa  ###
+###############################################################################
+
+###############################################################################
+### In order to override defaults - values can be assigned to the variables ###
+###############################################################################
+
+# Space or comma separated list of cc65 supported target platforms to build for.
+# Default: c64 (lowercase!)
+TARGETS := apple2cda
+
+# Name of the final, single-file executable.
+# Default: name of the current dir with target name appended
+PROGRAM := config
+
+# Path(s) to additional libraries required for linking the program
+# Use only if you don't want to place copies of the libraries in SRCDIR
+# Default: none
+LIBS	:=
+
+# Custom linker configuration file
+# Use only if you don't want to place it in SRCDIR
+# Default: none
+CONFIG  :=
+
+# Additional C compiler flags and options.
+# Default: none
+CFLAGS = -I -P cc=-i"src" cc=-i"src:apple2" cc=-i"13:cc65" cc=-dBUILD_APPLE2 cc=-d__APPLE2__ cc=-d__fastcall__= cc=-dBUILD_A2CDA
+
+# Additional assembler flags and options.
+# Default: none
+ASFLAGS =
+
+# Additional linker flags and options.
+# Default: none
+LDFLAGS = $(LDFLAGS.$(TARGETS))
+
+# Path to the directory containing C and ASM sources.
+# Default: src
+SRCDIR :=
+
+# Path to the directory where object files are to be stored (inside respective target subdirectories).
+# Default: obj
+OBJDIR :=
+
+# Command used to run the emulator.
+# Default: depending on target platform. For default (c64) target: x64 -kernal kernal -VICIIdsize -autoload
+EMUCMD :=
+
+# Optional commands used before starting the emulation process, and after finishing it.
+# Default: none
+#PREEMUCMD := osascript -e "tell application \"System Events\" to set isRunning to (name of processes) contains \"X11.bin\"" -e "if isRunning is true then tell application \"X11\" to activate"
+#PREEMUCMD := osascript -e "tell application \"X11\" to activate"
+#POSTEMUCMD := osascript -e "tell application \"System Events\" to tell process \"X11\" to set visible to false"
+#POSTEMUCMD := osascript -e "tell application \"Terminal\" to activate"
+PREEMUCMD :=
+POSTEMUCMD :=
+
+# On Windows machines VICE emulators may not be available in the PATH by default.
+# In such case, please set the variable below to point to directory containing
+# VICE emulators.
+#VICE_HOME := "C:\Program Files\WinVICE-2.2-x86\"
+VICE_HOME :=
+
+# Options state file name. You should not need to change this, but for those
+# rare cases when you feel you really need to name it differently - here you are
+STATEFILE := Makefile.options
+
+###################################################################################
+####  DO NOT EDIT BELOW THIS LINE, UNLESS YOU REALLY KNOW WHAT YOU ARE DOING!  ####
+###################################################################################
+
+###################################################################################
+### Mapping abstract options to the actual compiler, assembler and linker flags ###
+### Predefined compiler, assembler and linker flags, used with abstract options ###
+### valid for 2.14.x. Consult the documentation of your cc65 version before use ###
+###################################################################################
+
+# Compiler flags used to tell the compiler to optimise for SPEED
+define _optspeed_
+  CFLAGS += -Oris
+endef
+
+# Compiler flags used to tell the compiler to optimise for SIZE
+define _optsize_
+  CFLAGS += -Or
+endef
+
+# Compiler and assembler flags for generating listings
+define _listing_
+  CFLAGS += --listing $$(@:.root=.lst)
+  ASFLAGS += --listing $$(@:.root=.lst)
+  REMOVES += $(addsuffix .lst,$(basename $(OBJECTS)))
+endef
+
+# Linker flags for generating map file
+define _mapfile_
+  LDFLAGS += --mapfile $$@.map
+  REMOVES += $(PROGRAM).map
+endef
+
+# Linker flags for generating VICE label file
+define _labelfile_
+  LDFLAGS += -Ln $$@.lbl
+  REMOVES += $(PROGRAM).lbl
+endef
+
+# Linker flags for generating a debug file
+define _debugfile_
+  LDFLAGS += -Wl --dbgfile,$$@.dbg
+  REMOVES += $(PROGRAM).dbg
+endef
+
+###############################################################################
+###  Defaults to be used if nothing defined in the editable sections above  ###
+###############################################################################
+
+# Presume the C64 target like the cl65 compile & link utility does.
+# Set TARGETS to override.
+ifeq ($(TARGETS),)
+  TARGETS := c64
+endif
+
+# Presume we're in a project directory so name the program like the current
+# directory. Set PROGRAM to override.
+ifeq ($(PROGRAM),)
+  PROGRAM := $(notdir $(CURDIR))
+endif
+
+# Presume the C and asm source files to be located in the subdirectory 'src'.
+# Set SRCDIR to override.
+ifeq ($(SRCDIR),)
+  SRCDIR := src
+endif
+
+# Presume the object and dependency files to be located in the subdirectory
+# 'obj' (which will be created). Set OBJDIR to override.
+ifeq ($(OBJDIR),)
+  OBJDIR := obj
+endif
+TARGETOBJDIR := $(OBJDIR)/$(TARGETS)
+
+# On Windows it is mandatory to have CC65_HOME set. So do not unnecessarily
+# rely on cl65 being added to the PATH in this scenario.
+ifdef CC65_HOME
+  CC := $(CC65_HOME)/bin/cl65
+else
+  CC := cl65
+endif
+CC := iix compile
+LINKER := iix link
+
+# Default emulator commands and options for particular targets.
+# Set EMUCMD to override.
+c64_EMUCMD := $(VICE_HOME)xscpu64 -VICIIdsize -autostart
+c128_EMUCMD := $(VICE_HOME)x128 -kernal kernal -VICIIdsize -autoload
+vic20_EMUCMD := $(VICE_HOME)xvic -kernal kernal -VICdsize -autoload
+pet_EMUCMD := $(VICE_HOME)xpet -Crtcdsize -autoload
+plus4_EMUCMD := $(VICE_HOME)xplus4 -TEDdsize -autoload
+# So far there is no x16 emulator in VICE (why??) so we have to use xplus4 with -memsize option
+c16_EMUCMD := $(VICE_HOME)xplus4 -ramsize 16 -TEDdsize -autoload
+cbm510_EMUCMD := $(VICE_HOME)xcbm2 -model 510 -VICIIdsize -autoload
+cbm610_EMUCMD := $(VICE_HOME)xcbm2 -model 610 -Crtcdsize -autoload
+atari_EMUCMD := atari800 -windowed -xl -pal -nopatchall -run
+
+ifeq ($(EMUCMD),)
+  EMUCMD = $($(CC65TARGET)_EMUCMD)
+endif
+
+###############################################################################
+### The magic begins                                                        ###
+###############################################################################
+
+# The "Native Win32" GNU Make contains quite some workarounds to get along with
+# cmd.exe as shell. However it does not provide means to determine that it does
+# actually activate those workarounds. Especially does $(SHELL) NOT contain the
+# value 'cmd.exe'. So the usual way to determine if cmd.exe is being used is to
+# execute the command 'echo' without any parameters. Only cmd.exe will return a
+# non-empy string - saying 'ECHO is on/off'.
+#
+# Many "Native Win32" prorams accept '/' as directory delimiter just fine. How-
+# ever the internal commands of cmd.exe generally require '\' to be used.
+#
+# cmd.exe has an internal command 'mkdir' that doesn't understand nor require a
+# '-p' to create parent directories as needed.
+#
+# cmd.exe has an internal command 'del' that reports a syntax error if executed
+# without any file so make sure to call it only if there's an actual argument.
+ifeq ($(shell echo),)
+  MKDIR = mkdir -p $1
+  RMDIR = rmdir $1
+  RMFILES = $(RM) $1
+else
+  MKDIR = mkdir $(subst /,\,$1)
+  RMDIR = rmdir $(subst /,\,$1)
+  RMFILES = $(if $1,del /f $(subst /,\,$1))
+endif
+COMMA := ,
+SPACE := $(N/A) $(N/A)
+define NEWLINE
+
+
+endef
+# Note: Do not remove any of the two empty lines above !
+
+TARGETLIST := $(subst $(COMMA),$(SPACE),$(TARGETS))
+
+ifeq ($(words $(TARGETLIST)),1)
+
+# Set PROGRAM to something like 'myprog.c64'.
+override PROGRAM := $(PROGRAM)
+
+# Set SOURCES to something like 'src/foo.c src/bar.s'.
+# Use of assembler files with names ending differently than .s is deprecated!
+SOURCES := $(wildcard $(SRCDIR)/*.c)
+SOURCES += $(wildcard $(SRCDIR)/*.s)
+SOURCES += $(wildcard $(SRCDIR)/*.asm)
+SOURCES += $(wildcard $(SRCDIR)/*.a65)
+
+# Add to SOURCES something like 'src/c64/me.c src/c64/too.s'.
+# Use of assembler files with names ending differently than .s is deprecated!
+SOURCES += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.c)
+SOURCES += $(wildcard $(SRCDIR)/apple2/*.c)
+SOURCES += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.s)
+SOURCES += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.asm)
+SOURCES += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.a65)
+
+# Set OBJECTS to something like 'obj/c64/foo.o obj/c64/bar.o'.
+OBJECTS := $(addsuffix .root,$(basename $(addprefix $(TARGETOBJDIR)/,$(notdir $(SOURCES)))))
+
+# Set DEPENDS to something like 'obj/c64/foo.d obj/c64/bar.d'.
+DEPENDS := $(OBJECTS:.root=.d)
+
+# Add to LIBS something like 'src/foo.lib src/c64/bar.lib'.
+LIBS += $(wildcard $(SRCDIR)/*.lib)
+LIBS += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.lib)
+
+# Add to CONFIG something like 'src/c64/bar.cfg src/foo.cfg'.
+CONFIG += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.cfg)
+CONFIG += $(wildcard $(SRCDIR)/*.cfg)
+
+# Select CONFIG file to use. Target specific configs have higher priority.
+ifneq ($(word 2,$(CONFIG)),)
+  CONFIG := $(firstword $(CONFIG))
+  $(info Using config file $(CONFIG) for linking)
+endif
+
+.SUFFIXES:
+.PHONY: all test clean zap love
+
+all: $(PROGRAM)
+
+-include $(DEPENDS)
+-include $(STATEFILE)
+
+# If OPTIONS are given on the command line then save them to STATEFILE
+# if (and only if) they have actually changed. But if OPTIONS are not
+# given on the command line then load them from STATEFILE. Have object
+# files depend on STATEFILE only if it actually exists.
+ifeq ($(origin OPTIONS),command line)
+  ifneq ($(OPTIONS),$(_OPTIONS_))
+    ifeq ($(OPTIONS),)
+      $(info Removing OPTIONS)
+      $(shell $(RM) $(STATEFILE))
+      $(eval $(STATEFILE):)
+    else
+      $(info Saving OPTIONS=$(OPTIONS))
+      $(shell echo _OPTIONS_=$(OPTIONS) > $(STATEFILE))
+    endif
+    $(eval $(OBJECTS): $(STATEFILE))
+  endif
+else
+  ifeq ($(origin _OPTIONS_),file)
+    $(info Using saved OPTIONS=$(_OPTIONS_))
+    OPTIONS = $(_OPTIONS_)
+    $(eval $(OBJECTS): $(STATEFILE))
+  endif
+endif
+
+# Transform the abstract OPTIONS to the actual cc65 options.
+$(foreach o,$(subst $(COMMA),$(SPACE),$(OPTIONS)),$(eval $(_$o_)))
+
+# Strip potential variant suffix from the actual cc65 target.
+CC65TARGET := $(firstword $(subst .,$(SPACE),$(TARGETLIST)))
+
+# The remaining targets.
+$(TARGETOBJDIR):
+	$(call MKDIR,$@)
+
+vpath %.c $(SRCDIR)/apple2 $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
+
+$(TARGETOBJDIR)/%.root: %.c | $(TARGETOBJDIR)
+	$(CC) $< $(CFLAGS) keep=$(TARGETOBJDIR)/$$
+
+vpath %.s $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
+
+$(TARGETOBJDIR)/%.root: %.s | $(TARGETOBJDIR)
+	$(CC) -t $(CC65TARGET) -c --create-dep $(@:.o=.d) $(ASFLAGS) -o $@ $<
+
+vpath %.asm $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
+
+$(TARGETOBJDIR)/%.root: %.asm | $(TARGETOBJDIR)
+	$(CC) -t $(CC65TARGET) -c --create-dep $(@:.o=.d) $(ASFLAGS) -o $@ $<
+
+vpath %.a65 $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
+
+$(TARGETOBJDIR)/%.root: %.a65 | $(TARGETOBJDIR)
+	$(CC) -t $(CC65TARGET) -c --create-dep $(@:.o=.d) $(ASFLAGS) -o $@ $<
+
+$(PROGRAM): $(OBJECTS) $(LIBS)
+	$(LINKER) $(subst .root,,$^) keep=$@
+
+test: $(PROGRAM)
+	$(PREEMUCMD)
+	$(EMUCMD) $<
+	$(POSTEMUCMD)
+
+dist: $(PROGRAM)
+	     cp dist.apple2/bootable.po dist.apple2/dist.po
+#	     java -jar dist.apple2/ac.jar -as dist.apple2/dist.po config.system sys <config
+	     java -jar dist.apple2/ac.jar -p dist.apple2/dist.po fuji.da cda <config
+#	     cp dist.apple2/dist.po ../fujinet-platformio/data/webui/device_specific/BUILD_APPLE/autorun.po
+
+clean:
+	$(call RMFILES,$(OBJECTS))
+	$(call RMFILES,$(DEPENDS))
+	$(call RMFILES,$(REMOVES))
+	$(call RMFILES,$(PROGRAM))
+	$(call RMFILES,*.map)
+
+else # $(words $(TARGETLIST)),1
+
+all test clean:
+	$(foreach t,$(TARGETLIST),$(MAKE) TARGETS=$t $@$(NEWLINE))
+
+endif # $(words $(TARGETLIST)),1
+
+OBJDIRLIST := $(wildcard $(OBJDIR)/*)
+
+zap:
+	$(foreach o,$(OBJDIRLIST),-$(call RMFILES,$o/*.root $o/*.a $o/*.lst)$(NEWLINE))
+	$(foreach o,$(OBJDIRLIST),-$(call RMDIR,$o)$(NEWLINE))
+	-$(call RMDIR,$(OBJDIR))
+	-$(call RMFILES,$(basename $(PROGRAM)).* $(STATEFILE))
+
+love:
+	@echo "Not war, eh?"
+
+###################################################################
+###  Place your additional targets in the additional Makefiles  ###
+### in the same directory - their names have to end with ".mk"! ###
+###################################################################
+-include *.mk

--- a/Makefile.apple2gs
+++ b/Makefile.apple2gs
@@ -1,0 +1,355 @@
+###############################################################################
+### Generic Makefile for cc65 projects - full version with abstract options ###
+### V1.3.0(w) 2010 - 2013 Oliver Schmidt & Patryk "Silver Dream !" Łogiewa  ###
+###############################################################################
+
+###############################################################################
+### In order to override defaults - values can be assigned to the variables ###
+###############################################################################
+
+# Space or comma separated list of cc65 supported target platforms to build for.
+# Default: c64 (lowercase!)
+TARGETS := apple2gs
+
+# Name of the final, single-file executable.
+# Default: name of the current dir with target name appended
+PROGRAM := config
+
+# Path(s) to additional libraries required for linking the program
+# Use only if you don't want to place copies of the libraries in SRCDIR
+# Default: none
+LIBS	:=
+
+# Custom linker configuration file
+# Use only if you don't want to place it in SRCDIR
+# Default: none
+CONFIG  :=
+
+# Additional C compiler flags and options.
+# Default: none
+CFLAGS = -I -P cc=-i"src" cc=-i"src:apple2" cc=-i"13:cc65" cc=-dBUILD_APPLE2 cc=-d__APPLE2__ cc=-d__fastcall__=
+
+# Additional assembler flags and options.
+# Default: none
+ASFLAGS =
+
+# Additional linker flags and options.
+# Default: none
+LDFLAGS = $(LDFLAGS.$(TARGETS))
+
+# Path to the directory containing C and ASM sources.
+# Default: src
+SRCDIR :=
+
+# Path to the directory where object files are to be stored (inside respective target subdirectories).
+# Default: obj
+OBJDIR :=
+
+# Command used to run the emulator.
+# Default: depending on target platform. For default (c64) target: x64 -kernal kernal -VICIIdsize -autoload
+EMUCMD :=
+
+# Optional commands used before starting the emulation process, and after finishing it.
+# Default: none
+#PREEMUCMD := osascript -e "tell application \"System Events\" to set isRunning to (name of processes) contains \"X11.bin\"" -e "if isRunning is true then tell application \"X11\" to activate"
+#PREEMUCMD := osascript -e "tell application \"X11\" to activate"
+#POSTEMUCMD := osascript -e "tell application \"System Events\" to tell process \"X11\" to set visible to false"
+#POSTEMUCMD := osascript -e "tell application \"Terminal\" to activate"
+PREEMUCMD :=
+POSTEMUCMD :=
+
+# On Windows machines VICE emulators may not be available in the PATH by default.
+# In such case, please set the variable below to point to directory containing
+# VICE emulators.
+#VICE_HOME := "C:\Program Files\WinVICE-2.2-x86\"
+VICE_HOME :=
+
+# Options state file name. You should not need to change this, but for those
+# rare cases when you feel you really need to name it differently - here you are
+STATEFILE := Makefile.options
+
+###################################################################################
+####  DO NOT EDIT BELOW THIS LINE, UNLESS YOU REALLY KNOW WHAT YOU ARE DOING!  ####
+###################################################################################
+
+###################################################################################
+### Mapping abstract options to the actual compiler, assembler and linker flags ###
+### Predefined compiler, assembler and linker flags, used with abstract options ###
+### valid for 2.14.x. Consult the documentation of your cc65 version before use ###
+###################################################################################
+
+# Compiler flags used to tell the compiler to optimise for SPEED
+define _optspeed_
+  CFLAGS += -Oris
+endef
+
+# Compiler flags used to tell the compiler to optimise for SIZE
+define _optsize_
+  CFLAGS += -Or
+endef
+
+# Compiler and assembler flags for generating listings
+define _listing_
+  CFLAGS += --listing $$(@:.root=.lst)
+  ASFLAGS += --listing $$(@:.root=.lst)
+  REMOVES += $(addsuffix .lst,$(basename $(OBJECTS)))
+endef
+
+# Linker flags for generating map file
+define _mapfile_
+  LDFLAGS += --mapfile $$@.map
+  REMOVES += $(PROGRAM).map
+endef
+
+# Linker flags for generating VICE label file
+define _labelfile_
+  LDFLAGS += -Ln $$@.lbl
+  REMOVES += $(PROGRAM).lbl
+endef
+
+# Linker flags for generating a debug file
+define _debugfile_
+  LDFLAGS += -Wl --dbgfile,$$@.dbg
+  REMOVES += $(PROGRAM).dbg
+endef
+
+###############################################################################
+###  Defaults to be used if nothing defined in the editable sections above  ###
+###############################################################################
+
+# Presume the C64 target like the cl65 compile & link utility does.
+# Set TARGETS to override.
+ifeq ($(TARGETS),)
+  TARGETS := c64
+endif
+
+# Presume we're in a project directory so name the program like the current
+# directory. Set PROGRAM to override.
+ifeq ($(PROGRAM),)
+  PROGRAM := $(notdir $(CURDIR))
+endif
+
+# Presume the C and asm source files to be located in the subdirectory 'src'.
+# Set SRCDIR to override.
+ifeq ($(SRCDIR),)
+  SRCDIR := src
+endif
+
+# Presume the object and dependency files to be located in the subdirectory
+# 'obj' (which will be created). Set OBJDIR to override.
+ifeq ($(OBJDIR),)
+  OBJDIR := obj
+endif
+TARGETOBJDIR := $(OBJDIR)/$(TARGETS)
+
+# On Windows it is mandatory to have CC65_HOME set. So do not unnecessarily
+# rely on cl65 being added to the PATH in this scenario.
+ifdef CC65_HOME
+  CC := $(CC65_HOME)/bin/cl65
+else
+  CC := cl65
+endif
+CC := iix compile
+LINKER := iix link
+
+# Default emulator commands and options for particular targets.
+# Set EMUCMD to override.
+c64_EMUCMD := $(VICE_HOME)xscpu64 -VICIIdsize -autostart
+c128_EMUCMD := $(VICE_HOME)x128 -kernal kernal -VICIIdsize -autoload
+vic20_EMUCMD := $(VICE_HOME)xvic -kernal kernal -VICdsize -autoload
+pet_EMUCMD := $(VICE_HOME)xpet -Crtcdsize -autoload
+plus4_EMUCMD := $(VICE_HOME)xplus4 -TEDdsize -autoload
+# So far there is no x16 emulator in VICE (why??) so we have to use xplus4 with -memsize option
+c16_EMUCMD := $(VICE_HOME)xplus4 -ramsize 16 -TEDdsize -autoload
+cbm510_EMUCMD := $(VICE_HOME)xcbm2 -model 510 -VICIIdsize -autoload
+cbm610_EMUCMD := $(VICE_HOME)xcbm2 -model 610 -Crtcdsize -autoload
+atari_EMUCMD := atari800 -windowed -xl -pal -nopatchall -run
+
+ifeq ($(EMUCMD),)
+  EMUCMD = $($(CC65TARGET)_EMUCMD)
+endif
+
+###############################################################################
+### The magic begins                                                        ###
+###############################################################################
+
+# The "Native Win32" GNU Make contains quite some workarounds to get along with
+# cmd.exe as shell. However it does not provide means to determine that it does
+# actually activate those workarounds. Especially does $(SHELL) NOT contain the
+# value 'cmd.exe'. So the usual way to determine if cmd.exe is being used is to
+# execute the command 'echo' without any parameters. Only cmd.exe will return a
+# non-empy string - saying 'ECHO is on/off'.
+#
+# Many "Native Win32" prorams accept '/' as directory delimiter just fine. How-
+# ever the internal commands of cmd.exe generally require '\' to be used.
+#
+# cmd.exe has an internal command 'mkdir' that doesn't understand nor require a
+# '-p' to create parent directories as needed.
+#
+# cmd.exe has an internal command 'del' that reports a syntax error if executed
+# without any file so make sure to call it only if there's an actual argument.
+ifeq ($(shell echo),)
+  MKDIR = mkdir -p $1
+  RMDIR = rmdir $1
+  RMFILES = $(RM) $1
+else
+  MKDIR = mkdir $(subst /,\,$1)
+  RMDIR = rmdir $(subst /,\,$1)
+  RMFILES = $(if $1,del /f $(subst /,\,$1))
+endif
+COMMA := ,
+SPACE := $(N/A) $(N/A)
+define NEWLINE
+
+
+endef
+# Note: Do not remove any of the two empty lines above !
+
+TARGETLIST := $(subst $(COMMA),$(SPACE),$(TARGETS))
+
+ifeq ($(words $(TARGETLIST)),1)
+
+# Set PROGRAM to something like 'myprog.c64'.
+override PROGRAM := $(PROGRAM)
+
+# Set SOURCES to something like 'src/foo.c src/bar.s'.
+# Use of assembler files with names ending differently than .s is deprecated!
+SOURCES := $(wildcard $(SRCDIR)/*.c)
+SOURCES += $(wildcard $(SRCDIR)/*.s)
+SOURCES += $(wildcard $(SRCDIR)/*.asm)
+SOURCES += $(wildcard $(SRCDIR)/*.a65)
+
+# Add to SOURCES something like 'src/c64/me.c src/c64/too.s'.
+# Use of assembler files with names ending differently than .s is deprecated!
+SOURCES += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.c)
+SOURCES += $(wildcard $(SRCDIR)/apple2/*.c)
+SOURCES += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.s)
+SOURCES += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.asm)
+SOURCES += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.a65)
+
+# Set OBJECTS to something like 'obj/c64/foo.o obj/c64/bar.o'.
+OBJECTS := $(addsuffix .root,$(basename $(addprefix $(TARGETOBJDIR)/,$(notdir $(SOURCES)))))
+
+# Set DEPENDS to something like 'obj/c64/foo.d obj/c64/bar.d'.
+DEPENDS := $(OBJECTS:.root=.d)
+
+# Add to LIBS something like 'src/foo.lib src/c64/bar.lib'.
+LIBS += $(wildcard $(SRCDIR)/*.lib)
+LIBS += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.lib)
+
+# Add to CONFIG something like 'src/c64/bar.cfg src/foo.cfg'.
+CONFIG += $(wildcard $(SRCDIR)/$(TARGETLIST)/*.cfg)
+CONFIG += $(wildcard $(SRCDIR)/*.cfg)
+
+# Select CONFIG file to use. Target specific configs have higher priority.
+ifneq ($(word 2,$(CONFIG)),)
+  CONFIG := $(firstword $(CONFIG))
+  $(info Using config file $(CONFIG) for linking)
+endif
+
+.SUFFIXES:
+.PHONY: all test clean zap love
+
+all: $(PROGRAM)
+
+-include $(DEPENDS)
+-include $(STATEFILE)
+
+# If OPTIONS are given on the command line then save them to STATEFILE
+# if (and only if) they have actually changed. But if OPTIONS are not
+# given on the command line then load them from STATEFILE. Have object
+# files depend on STATEFILE only if it actually exists.
+ifeq ($(origin OPTIONS),command line)
+  ifneq ($(OPTIONS),$(_OPTIONS_))
+    ifeq ($(OPTIONS),)
+      $(info Removing OPTIONS)
+      $(shell $(RM) $(STATEFILE))
+      $(eval $(STATEFILE):)
+    else
+      $(info Saving OPTIONS=$(OPTIONS))
+      $(shell echo _OPTIONS_=$(OPTIONS) > $(STATEFILE))
+    endif
+    $(eval $(OBJECTS): $(STATEFILE))
+  endif
+else
+  ifeq ($(origin _OPTIONS_),file)
+    $(info Using saved OPTIONS=$(_OPTIONS_))
+    OPTIONS = $(_OPTIONS_)
+    $(eval $(OBJECTS): $(STATEFILE))
+  endif
+endif
+
+# Transform the abstract OPTIONS to the actual cc65 options.
+$(foreach o,$(subst $(COMMA),$(SPACE),$(OPTIONS)),$(eval $(_$o_)))
+
+# Strip potential variant suffix from the actual cc65 target.
+CC65TARGET := $(firstword $(subst .,$(SPACE),$(TARGETLIST)))
+
+# The remaining targets.
+$(TARGETOBJDIR):
+	$(call MKDIR,$@)
+
+vpath %.c $(SRCDIR)/apple2 $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
+
+$(TARGETOBJDIR)/%.root: %.c | $(TARGETOBJDIR)
+	$(CC) $< $(CFLAGS) keep=$(TARGETOBJDIR)/$$
+
+vpath %.s $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
+
+$(TARGETOBJDIR)/%.root: %.s | $(TARGETOBJDIR)
+	$(CC) -t $(CC65TARGET) -c --create-dep $(@:.o=.d) $(ASFLAGS) -o $@ $<
+
+vpath %.asm $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
+
+$(TARGETOBJDIR)/%.root: %.asm | $(TARGETOBJDIR)
+	$(CC) -t $(CC65TARGET) -c --create-dep $(@:.o=.d) $(ASFLAGS) -o $@ $<
+
+vpath %.a65 $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
+
+$(TARGETOBJDIR)/%.root: %.a65 | $(TARGETOBJDIR)
+	$(CC) -t $(CC65TARGET) -c --create-dep $(@:.o=.d) $(ASFLAGS) -o $@ $<
+
+$(PROGRAM): $(OBJECTS) $(LIBS)
+	$(LINKER) $(subst .root,,$^) keep=$@
+
+test: $(PROGRAM)
+	$(PREEMUCMD)
+	$(EMUCMD) $<
+	$(POSTEMUCMD)
+
+dist: $(PROGRAM)
+	     cp dist.apple2/bootable.po dist.apple2/dist.po
+#	     java -jar dist.apple2/ac.jar -as dist.apple2/dist.po config.system sys <config
+	     java -jar dist.apple2/ac.jar -p dist.apple2/dist.po config exe <config
+#	     cp dist.apple2/dist.po ../fujinet-platformio/data/webui/device_specific/BUILD_APPLE/autorun.po
+
+clean:
+	$(call RMFILES,$(OBJECTS))
+	$(call RMFILES,$(DEPENDS))
+	$(call RMFILES,$(REMOVES))
+	$(call RMFILES,$(PROGRAM))
+	$(call RMFILES,*.map)
+
+else # $(words $(TARGETLIST)),1
+
+all test clean:
+	$(foreach t,$(TARGETLIST),$(MAKE) TARGETS=$t $@$(NEWLINE))
+
+endif # $(words $(TARGETLIST)),1
+
+OBJDIRLIST := $(wildcard $(OBJDIR)/*)
+
+zap:
+	$(foreach o,$(OBJDIRLIST),-$(call RMFILES,$o/*.root $o/*.a $o/*.lst)$(NEWLINE))
+	$(foreach o,$(OBJDIRLIST),-$(call RMDIR,$o)$(NEWLINE))
+	-$(call RMDIR,$(OBJDIR))
+	-$(call RMFILES,$(basename $(PROGRAM)).* $(STATEFILE))
+
+love:
+	@echo "Not war, eh?"
+
+###################################################################
+###  Place your additional targets in the additional Makefiles  ###
+### in the same directory - their names have to end with ".mk"! ###
+###################################################################
+-include *.mk

--- a/src/apple2/bar.c
+++ b/src/apple2/bar.c
@@ -44,12 +44,25 @@ void bar_clear(bool oldRow)
 void bar_update(void)
 {
   char i;
+  #ifdef __ORCAC__
+  unsigned short addr;
+  #endif
 
   bar_clear(true);
 
   // Clear bar color
-  for (i=0;i<40;i++)
-    ram[bar_coord(i,bar_y+bar_i)] &= 0x3f; // black char on white background is in lower half of char set
+  #ifdef __ORCAC__
+    for (i=0;i<40;i++) {
+      addr = bar_coord(i,bar_y+bar_i);
+      if (ram[addr] >= 0xe0)
+        ram[addr] &= 0x7f;
+      else
+        ram[addr] &= 0x3f; // black char on white background is in lower half of char set
+    }
+  #else
+    for (i=0;i<40;i++)
+      ram[bar_coord(i,bar_y+bar_i)] &= 0x3f; // black char on white background is in lower half of char set
+  #endif
 }
 
 /**

--- a/src/apple2/bar.c
+++ b/src/apple2/bar.c
@@ -3,6 +3,10 @@
  * Bar routines
  */
 
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
+
 #include <peekpoke.h>
 #include "bar.h"
 

--- a/src/apple2/cc65lib.c
+++ b/src/apple2/cc65lib.c
@@ -1,0 +1,159 @@
+#ifdef __ORCAC__
+
+/**
+ * FujiNet CONFIG for Apple IIgs
+ *
+ * cc65 compatibility for ORCA/C
+ */
+
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <texttool.h>
+#include <peekpoke.h>
+#include <conio.h>
+#include <apple2.h>
+
+static char buffer[121];
+
+/* Functions from conio */
+
+void clrscr (void)
+/* Clear the whole screen and put the cursor into the top left corner */
+{
+  WriteChar(0x8c);
+}
+
+void gotox (unsigned char x)
+/* Set the cursor to the specified X position, leave the Y position untouched */
+{
+  POKE(0x24, x);
+  POKE(0x57b, x);
+}
+
+void gotoy (unsigned char y)
+/* Set the cursor to the specified Y position, leave the X position untouched */
+{
+  unsigned char x;
+
+  x = wherex();
+  POKE(0x25, y-1);
+  WriteChar(0x8d);
+  POKE(0x24, x);
+  POKE(0x57b, x);
+}
+
+void gotoxy (unsigned char x, unsigned char y)
+/* Set the cursor to the specified position */
+{
+  POKE(0x25, y-1);
+  WriteChar(0x8d);
+  POKE(0x24, x);
+  POKE(0x57b, x);
+}
+
+unsigned char wherex (void)
+/* Return the X position of the cursor */
+{
+  return PEEK(0x57b);
+}
+
+unsigned char wherey (void)
+/* Return the Y position of the cursor */
+{
+  return PEEK(0x25);
+}
+
+void cputc (char c)
+/* Output one character at the current cursor position */
+{
+  WriteChar(c);
+}
+
+void cputs (const char* s)
+/* Output a NUL-terminated string at the current cursor position */
+{
+  char prev;
+
+  while (prev = *s) {
+    if (*s == '\r' && wherey() == 23)
+      gotoxy(0, 0);
+    else
+      WriteChar(*s);
+    if (*++s == '\n' && prev == '\r')
+      s++;
+  }
+}
+
+int cprintf (const char* format, ...)
+/* Like printf(), but uses direct screen output */
+{
+  va_list args;
+
+  va_start(args, format);
+  vsprintf(buffer, format, args);
+  va_end(args);
+  cputs(buffer);
+}
+
+char cgetc (void)
+/* Return a character from the keyboard. If there is no character available,
+** the function waits until the user does press a key. If cursor is set to
+** 1 (see below), a blinking cursor is displayed while waiting.
+*/
+{
+  return (char)ReadChar(noEcho);
+}
+
+unsigned char revers (unsigned char onoff)
+/* Enable/disable reverse character display. This may not be supported by
+** the output device. Return the old setting.
+*/
+{
+  if (onoff)
+    WriteChar(0x8f);
+  else
+    WriteChar(0x8e);
+}
+
+void chline (unsigned char length)
+/* Output a horizontal line with the given length starting at the current
+** cursor position.
+*/
+{
+  memset(buffer, '-', length);
+  buffer[length] = '\0';
+  WriteCString(buffer);
+}
+
+void chlinexy (unsigned char x, unsigned char y, unsigned char length)
+/* Same as "gotoxy (x, y); chline (length);" */
+{
+  gotoxy(x, y);
+  chline(length);
+}
+
+void cclear (unsigned char length)
+/* Clear part of a line (write length spaces). */
+{
+  memset(buffer, 0xa0, length-1);
+  buffer[length-1] = '\0';
+  WriteCString(buffer);
+}
+
+void cclearxy (unsigned char x, unsigned char y, unsigned char length)
+/* Same as "gotoxy (x, y); cclear (length);" */
+{
+  gotoxy(x, y);
+  cclear(length);
+}
+
+/* Functions from apple2 */
+
+unsigned char get_ostype (void)
+/* Get the machine type. Returns one of the APPLE_xxx codes. */
+{
+  return APPLE_II;
+}
+
+#endif /* __ORCAC__ */

--- a/src/apple2/cursor.c
+++ b/src/apple2/cursor.c
@@ -5,6 +5,10 @@
  * Cursor routines
  */
 
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
+
 #include "cursor.h"
 
 #define UNUSED(x) (void)(x)

--- a/src/apple2/die.c
+++ b/src/apple2/die.c
@@ -4,6 +4,10 @@
  * Die function
  */
 #ifdef BUILD_APPLE2
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
+
 #include "../die.h"
 
 void die(void)

--- a/src/apple2/input.c
+++ b/src/apple2/input.c
@@ -3,6 +3,10 @@
  * Input routines
  */
 
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
+
 #include <conio.h>
 #include <string.h>
 #include <stdbool.h>

--- a/src/apple2/io.c
+++ b/src/apple2/io.c
@@ -340,6 +340,7 @@ void io_copy_file(unsigned char source_slot, unsigned char destination_slot)
   sp_error = sp_control(sp_dest, FUJICMD_COPY_FILE);
 }
 
+#ifndef __ORCAC__
 void io_set_boot_config(uint8_t toggle)
 {
   sp_payload[0] = 1;
@@ -348,6 +349,7 @@ void io_set_boot_config(uint8_t toggle)
 
   sp_error = sp_control(sp_dest, FUJICMD_CONFIG_BOOT);
 }
+#endif
 
 void io_umount_disk_image(uint8_t ds)
 {
@@ -400,6 +402,7 @@ unsigned char io_device_slot_to_device(unsigned char ds)
   return ds;
 }
 
+#ifndef __ORCAC__
 void io_boot(void)
 {
   char ostype;
@@ -431,6 +434,7 @@ void io_boot(void)
     asm("JMP $0100");
   }
 }
+#endif
 
 bool io_get_wifi_enabled(void)
 {

--- a/src/apple2/io.c
+++ b/src/apple2/io.c
@@ -4,6 +4,11 @@
  *
  * I/O Routines
  */
+
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
+
 #include "io.h"
 #include <stdint.h>
 #include <conio.h>

--- a/src/apple2/screen.c
+++ b/src/apple2/screen.c
@@ -5,6 +5,10 @@
  * Screen Routines
  */
 
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
+
 #include "screen.h"
 #include "globals.h"
 #include "bar.h"

--- a/src/apple2/screen.c
+++ b/src/apple2/screen.c
@@ -273,7 +273,11 @@ void screen_hosts_and_devices_hosts(void)
   screen_print_menu("RETURN",":SELECT FILES\r\n ");
   screen_print_menu("C","ONFIG  ");
   screen_print_menu("TAB",":DRIVE SLOTS  ");
-  screen_print_menu("ESC",":BOOT");
+  #ifdef __ORCAC__
+    screen_print_menu("ESC",":EXIT");
+  #else
+    screen_print_menu("ESC",":BOOT");
+  #endif
 }
 
 void screen_hosts_and_devices_host_slots(HostSlot *h)
@@ -525,6 +529,6 @@ void screen_hosts_and_devices_eject(unsigned char ds)
 
 void screen_hosts_and_devices_host_slot_empty(unsigned char hs)
 {
-  gotoxy(2,2+hs); cprintf("Empty");
+  gotoxy(2,1+hs); cprintf("Empty");
 }
 #endif /* BUILD_APPLE2 */

--- a/src/apple2/sp.c
+++ b/src/apple2/sp.c
@@ -5,6 +5,10 @@
  * SmartPort MLI Routines
  */
 
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
+
 #ifdef __INTELLISENSE__
 // 18, expect closing parenthses - needed to use cc65 inline asm command with agruments.
   #pragma diag_suppress 18

--- a/src/apple2/sp.h
+++ b/src/apple2/sp.h
@@ -10,7 +10,11 @@
 
 #include <stdint.h>
 
+#ifdef __ORCAC__
+extern uint8_t *sp_payload;
+#else
 extern uint8_t sp_payload[1024];
+#endif
 extern uint16_t sp_count, sp_dispatch;
 extern uint8_t sp_dest;
 extern uint8_t sp_error;
@@ -21,7 +25,9 @@ int8_t sp_find_fuji(void);
 uint8_t sp_find_slot(void);
 uint16_t sp_dispatch_address(uint8_t slot);
 void sp_init(void);
-
+#ifdef __ORCAC__
+void sp_done(void);
+#endif
 void sp_list_devs();
 
 #endif /* SP_H */

--- a/src/check_wifi.c
+++ b/src/check_wifi.c
@@ -10,6 +10,9 @@
 #endif /* BUILD_ADAM */
 
 #ifdef BUILD_APPLE2
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
 #include "apple2/io.h"
 #include "apple2/globals.h"
 #endif /* BUILD_APPLE2 */

--- a/src/connect_wifi.c
+++ b/src/connect_wifi.c
@@ -14,6 +14,9 @@
 #endif /* BUILD_ADAM */
 
 #ifdef BUILD_APPLE2
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
 #include "apple2/io.h"
 #include "apple2/screen.h"
 #include "apple2/globals.h"

--- a/src/connect_wifi.c
+++ b/src/connect_wifi.c
@@ -50,7 +50,7 @@
 void connect_wifi(void)
 {
 	unsigned char retries = 20;
-	NetConfig nc;
+	static NetConfig nc;
 	unsigned char s;
 
 	memcpy(&nc, io_get_ssid(), sizeof(NetConfig));

--- a/src/destination_host_slot.c
+++ b/src/destination_host_slot.c
@@ -19,6 +19,9 @@
 #endif /* BUILD_ADAM */
 
 #ifdef BUILD_APPLE2
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
 #include "apple2/screen.h"
 #include "apple2/input.h"
 #include "apple2/globals.h"

--- a/src/hosts_and_devices.c
+++ b/src/hosts_and_devices.c
@@ -19,6 +19,9 @@
 #endif /* BUILD_ADAM */
 
 #ifdef BUILD_APPLE2
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
 #include "apple2/globals.h"
 #include "apple2/fuji_typedefs.h"
 #include "apple2/io.h"

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,9 @@
 #endif /* BUILD_ADAM */
 
 #ifdef BUILD_APPLE2
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
 #include "apple2/io.h"
 #include "apple2/screen.h"
 #include "apple2/sp.h"
@@ -75,7 +78,6 @@ void done(void)
 {
   #ifdef __ORCAC__
 	sp_done();
-	clrscr();
 	WriteChar(0x92);  // Set 80 col
 	WriteChar(0x86);  // Cursor on
 	TextShutDown();
@@ -129,9 +131,22 @@ void run(void)
   }
 }
 
+#ifdef BUILD_A2CDA
+void Start(void)
+{
+	setup();
+	state = CHECK_WIFI;
+	run();
+}
+
+void ShutDown(void)
+{
+}
+#else
 void main(void)
 {
 	setup();
 	state = CHECK_WIFI;
 	run();
 }
+#endif /* BUILD_A2CDA */

--- a/src/main.c
+++ b/src/main.c
@@ -48,19 +48,42 @@
 #include "pc6001/screen.h"
 #endif /* BUILD_PC6001 */
 
+#ifdef __ORCAC__
+#include <texttool.h>
+#endif
+
 State state=HOSTS_AND_DEVICES;
 
 void setup(void)
 {
+  #ifdef __ORCAC__
+	TextStartUp();
+	SetInGlobals(0x7f, 0x00);
+	SetOutGlobals(0xff, 0x80);
+	SetInputDevice(basicType, 3);
+	SetOutputDevice(basicType, 3);
+	InitTextDev(input);
+	InitTextDev(output);
+	WriteChar(0x91);  // Set 40 col
+	WriteChar(0x85);  // Cursor off
+  #endif
   io_init();
   screen_init();
 }
 
 void done(void)
 {
+  #ifdef __ORCAC__
+	sp_done();
+	clrscr();
+	WriteChar(0x92);  // Set 80 col
+	WriteChar(0x86);  // Cursor on
+	TextShutDown();
+  #else
   // reboot here
   io_set_boot_config(0); // disable config
   io_boot();             // and reboot.
+  #endif
 }
 
 void run(void)
@@ -98,6 +121,9 @@ void run(void)
 			break;
 		case DONE:
 			done();
+			#ifdef __ORCAC__
+			return;
+			#endif
 			break;
 		}
   }

--- a/src/perform_copy.c
+++ b/src/perform_copy.c
@@ -17,6 +17,9 @@
 #endif /* BUILD_ADAM */
 
 #ifdef BUILD_APPLE2
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
 #include "apple2/fuji_typedefs.h"
 #include "apple2/screen.h"
 #include "apple2/io.h"

--- a/src/select_file.c
+++ b/src/select_file.c
@@ -302,10 +302,10 @@ void select_file_devance(void)
   sf_subState = SF_DISPLAY; // And display the result.
 }
 
-bool select_file_is_folder(void)
+unsigned char select_file_is_folder(void)
 {
   char *e;
-  bool result;
+  unsigned char result;
 
   io_open_directory(selected_host_slot, path, filter);
 

--- a/src/select_file.c
+++ b/src/select_file.c
@@ -30,6 +30,9 @@
 #endif
 
 #ifdef BUILD_APPLE2
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
 #include "apple2/fuji_typedefs.h"
 #include "apple2/screen.h"
 #include "apple2/io.h"

--- a/src/select_slot.c
+++ b/src/select_slot.c
@@ -20,6 +20,9 @@
 #endif /* BUILD_ADAM */
 
 #ifdef BUILD_APPLE2
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
 #include "apple2/screen.h"
 #include "apple2/input.h"
 #include "apple2/globals.h"
@@ -125,7 +128,7 @@ void select_slot_choose()
 
 void select_slot_done()
 {
-  char filename[256];
+  static char filename[256];
 
   memset(filename,0,sizeof(filename));
 

--- a/src/set_wifi.c
+++ b/src/set_wifi.c
@@ -20,6 +20,9 @@
 #endif /* BUILD_ADAM */
 
 #ifdef BUILD_APPLE2
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
 #include "apple2/io.h"
 #include "apple2/fuji_typedefs.h"
 #include "apple2/screen.h"

--- a/src/show_info.c
+++ b/src/show_info.c
@@ -15,6 +15,9 @@
 #endif /* BUILD_ADAM */
 
 #ifdef BUILD_APPLE2
+#ifdef BUILD_A2CDA
+#pragma cda "FujiNet Config" Start ShutDown
+#endif /* BUILD_A2CDA */
 #include "apple2/screen.h"
 #include "apple2/input.h"
 #include "apple2/globals.h"


### PR DESCRIPTION
The new Makefile.apple2gs and Makefile.apple2cda target the GoldenGate and ORCA/C build environment.

- Makefile.apple2gs builds a config EXE file which can run in native GS mode under ORCA shell.
- Makefile.apple2cda builds a CDA (Classic Desk Accessory).

Conditional compile directives have been used not to break cc65 compatibility. ORCA/C specific code is protected by `#ifdef __ORCAC__`/`#else`/`#endif`. CDA specific code is protected by `#ifdef BUILD_A2CDA`/`#endif`.

Build requirements:

- [GoldenGate](https://gitlab.com/GoldenGate/GoldenGate). Installation instructions are available at <https://goldengate.gitlab.io/manual/>.
- [ORCA/C](https://juiced.gs/store/opus-ii-software/)

In addition, the cc65 headers conio.h, apple2.h and peekpoke.h should be present on the GoldenGate install under ~/GoldenGate/Libraries/cc65. These are available here: <https://github.com/cc65/cc65/tree/master/include>.