### PR TITLE
Conditional compilation for Atari/IIgs compat

### DIFF
--- a/src/select_slot.c
+++ b/src/select_slot.c
@@ -128,7 +128,11 @@ void select_slot_choose()
 
 void select_slot_done()
 {
+  #ifdef __ORCAC__
   static char filename[256];
+  #else
+  char filename[256];
+  #endif
 
   memset(filename,0,sizeof(filename));
 


### PR DESCRIPTION
Anterior change to static storage class for filename in select_slot_done() caused screen corruption for the Atari.

Conditional compilation was added to enable static storage class for Apple IIgs ORCA/C compiler only.