### PR TITLE
support override of dest dir in Makefile.c64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+a.out
 obj
 *.swp
 *.c~

--- a/Makefile.c64
+++ b/Makefile.c64
@@ -41,6 +41,10 @@ LDFLAGS = $(LDFLAGS.$(TARGETS))
 # Default: src
 SRCDIR :=
 
+# Path to the directory to output binary to 
+# Default: ~/Workspace/tnfs 
+DESTDIR := 
+
 # Path to the directory where object files are to be stored (inside respective target subdirectories).
 # Default: obj
 OBJDIR :=
@@ -133,6 +137,12 @@ endif
 # Set SRCDIR to override.
 ifeq ($(SRCDIR),)
   SRCDIR := src
+endif
+
+# Presume the destination for the binary in the subdirectory '/Workspace/tnfs'.
+# Set DESTDIR to override.
+ifeq ($(DESTDIR),)
+  DESTDIR := ~/Workspace/tnfs 
 endif
 
 # Presume the object and dependency files to be located in the subdirectory
@@ -316,7 +326,7 @@ test: $(PROGRAM)
 
 dist: $(PROGRAM)
 	exomizer sfx sys config
-	cp a.out ~/Workspace/tnfs/config
+	cp a.out $(DESTDIR)/config
 
 clean:
 	$(call RMFILES,$(OBJECTS))


### PR DESCRIPTION
Adding `DESTDIR` as an override variable in the `Makefile.c64`.
