### PR TITLE
Remove direct RAM access for ORCA/C

### DIFF
--- a/src/apple2/bar.c
+++ b/src/apple2/bar.c
@@ -16,19 +16,6 @@
  */
 static unsigned char bar_y=3, bar_c=1, bar_m=1, bar_i=0, bar_oldi=0;
 
-#ifdef __ORCAC__
-unsigned char *ram = (unsigned char *)0x0000;
-const unsigned short row[24]= {
-			       0x0400, 0x0480, 0x0500, 0x0580, 0x0600, 0x0680, 0x0700,
-			       0x0780, 0x0428, 0x04A8, 0x0528, 0x05A8, 0x0628, 0x06A8, 0x0728, 0x07A8,
-			       0x0450, 0x04D0, 0x0550, 0x05D0, 0x0650, 0x06D0, 0x0750, 0x07D0
-};
-unsigned short bar_coord(unsigned char x, unsigned char y)
-{
-  return row[y]+x;
-}
-#endif
-
 void bar_clear(bool oldRow)
 {
   char i;
@@ -39,14 +26,9 @@ void bar_clear(bool oldRow)
   else
     by = bar_y + bar_i;
 
-#ifdef __ORCAC__
-  for (i = 0; i < 40; i++)
-    ram[bar_coord(i, by)] |= 0x80; // white char on black background is in upper half of char set
-#else
   gotoy(by);
   for (i = 0; i < 40; i++)
     CURRENT_LINE[i] |= 0x80; // white char on black background is in upper half of char set
-#endif
 }
 
 /**
@@ -55,26 +37,13 @@ void bar_clear(bool oldRow)
 void bar_update(void)
 {
   char i;
-  #ifdef __ORCAC__
-  unsigned short addr;
-  #endif
 
   bar_clear(true);
 
   // Clear bar color
-  #ifdef __ORCAC__
-    for (i = 0; i < 40; i++) {
-      addr = bar_coord(i,bar_y + bar_i);
-      if (ram[addr] >= 0xe0)
-        ram[addr] &= 0x7f;
-      else
-        ram[addr] &= 0x3f; // black char on white background is in lower half of char set
-    }
-  #else
     gotoy(bar_y + bar_i);
     for (i = 0; i < 40; i++)
       CURRENT_LINE[i] &= 0x3f; // black char on white background is in lower half of char set
-  #endif
 }
 
 /**

--- a/src/apple2/bar.h
+++ b/src/apple2/bar.h
@@ -8,12 +8,7 @@
 
 #include "globals.h"
 
-#ifdef __ORCAC__
-extern unsigned char *ram;
-unsigned short bar_coord(unsigned char x, unsigned char y);
-#else
 #define CURRENT_LINE (*(char**)0x28)
-#endif
 
 /**
  * Clear the currently displayed bar from screen

--- a/src/apple2/cc65lib.c
+++ b/src/apple2/cc65lib.c
@@ -70,6 +70,8 @@ unsigned char wherey (void)
 void cputc (char c)
 /* Output one character at the current cursor position */
 {
+  if ((c & 0x60) == 0x60) /* Lower case */
+    c -= 32;            /* Convert to upper case */
   WriteChar(c);
 }
 
@@ -85,7 +87,7 @@ void cputs (const char* s)
       POKE(0x57b, 0);
     }
     else
-      WriteChar(*s);
+      cputc(*s);
     if (*++s == '\n' && x == '\r')
       s++;
   }
@@ -162,7 +164,7 @@ void cclearxy (unsigned char x, unsigned char y, unsigned char length)
 unsigned char get_ostype (void)
 /* Get the machine type. Returns one of the APPLE_xxx codes. */
 {
-  return APPLE_II;
+  return APPLE_IIGS;
 }
 
 #endif /* __ORCAC__ */

--- a/src/apple2/screen.c
+++ b/src/apple2/screen.c
@@ -96,11 +96,7 @@ void screen_putlcc(char c)
     break;
   }
 
-#ifdef __ORCAC__
-  ram[bar_coord(wherex(), wherey())] = c + modifier;
-#else
   CURRENT_LINE[wherex()] = c + modifier;
-#endif
 }
 
 void screen_set_wifi(AdapterConfig *ac)


### PR DESCRIPTION
The following commit removes the specific ORCA/C (IIgs) code left over from PR #47. Changes made by Oliver Schmidt are compatible with the ORCA/C version. The operation of the CDA and EXE shell commands has been verified.