### PR TITLE
Small fix for path length

### DIFF
--- a/src/select_file.c
+++ b/src/select_file.c
@@ -96,7 +96,7 @@ void select_file_init(void)
   io_close_directory();
   pos = 0;
   memset(entry_size, 0, ENTRIES_PER_PAGE);
-  memset(path, 0, 256);
+  memset(path, 0, 224);
   path[0] = '/';
   memset(filter, 0, 32);
   screen_select_file();


### PR DESCRIPTION
Minor bug, memset is overrunning field.
Fortunately it runs into filter, which is next memory location, so would only error if they were not contiguous.
However, filter is later cleared separately, so this also fixes double cleaning of same location.
