### PR TITLE
removing clrscr from perform_copy, it is not cross-platform. The plat…

### DIFF
--- a/src/perform_copy.c
+++ b/src/perform_copy.c
@@ -80,8 +80,6 @@ void perform_copy(void)
   strcat(copySpec, path);
   strcat(copySpec,source_filename);
   
-  clrscr();
-
   screen_perform_copy((char *)hostSlots[copy_host_slot],(char *)source_path,(char *)hostSlots[selected_host_slot],(char *)path);
 
   io_copy_file(copy_host_slot, selected_host_slot);


### PR DESCRIPTION
…form instance of screen_perform_copy does its own screen clearing in all cases anyway