### PR TITLE
RC2014: fix regressions

### DIFF
--- a/Makefile.rc2014
+++ b/Makefile.rc2014
@@ -13,7 +13,7 @@ SRCS := $(shell find $(SRC_DIRS) -name *.cpp -or -name *.c -or -name *.asm)
 OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
-CFLAGS=+cpm -DBUILD_RC2014 -I$(LIB_PROJECT_INC) -clib=ansi -pragma-redirect:fputc_cons=fputc_cons_generic
+CFLAGS=+cpm -DBUILD_RC2014 -I$(LIB_PROJECT_INC) -compiler=sdcc -clib=ansi -pragma-redirect:fputc_cons=fputc_cons_generic
 LDFLAGS=+cpm -create-app -I$(LIB_PROJECT_INC) -o$(TARGET_EXEC)
 ASFLAGS=+cpm
 

--- a/src/rc2014/bar.h
+++ b/src/rc2014/bar.h
@@ -14,6 +14,8 @@
  */
 void bar_clear(bool old);
 
+void bar_update(void);
+
 /**
  * Set up bar and start display on row
  * @param y Y column for bar display

--- a/src/rc2014/input.c
+++ b/src/rc2014/input.c
@@ -85,7 +85,7 @@ void input_line(unsigned char x, unsigned char y, unsigned char o, char *c, unsi
   // x += o;
 
   cursor_pos(0, y);
-    cputc(":");
+  cputc(':');
   while(1)
   {
     cursor_pos(x + i, y);

--- a/src/rc2014/io.c
+++ b/src/rc2014/io.c
@@ -18,11 +18,11 @@
 #undef MOCK_DEVICES
 #undef MOCK_HOSTS
 
-static uint8_t response[1024];
-static FUJINET_RC last_rc = FUJINET_RC_OK;
+uint8_t response[1024];
+FUJINET_RC last_rc = FUJINET_RC_OK;
 
-extern unsigned char source_path;
-extern unsigned char path;
+extern unsigned char source_path[224];
+extern unsigned char path[224];
 
 #ifdef MOCK_WIFI
 AdapterConfig mock_cfg = {
@@ -110,8 +110,10 @@ NetConfig* io_get_ssid(void)
   last_rc = FUJINET_RC_OK;
   return mock_netconfig;
 #else
-  last_rc = fujinet_get_ssid(response);
-  return (NetConfig *)response;
+
+  NetConfig* nc = (NetConfig*)response;
+  last_rc = fujinet_get_ssid(nc);
+  return nc;
 #endif
 }
 
@@ -132,8 +134,9 @@ SSIDInfo *io_get_scan_result(unsigned char n)
   last_rc = FUJINET_RC_OK;
   return &mock_ssid[n];
 #else
-  last_rc = fujinet_get_scan_result(n, response);
-  return (SSIDInfo *)response;
+  SSIDInfo* info = (SSIDInfo*)response;
+  last_rc = fujinet_get_scan_result(n, info);
+  return info;
 #endif
 }
 
@@ -143,8 +146,9 @@ AdapterConfig *io_get_adapter_config(void)
   last_rc = FUJINET_RC_OK;
   return mock_cfg;
 #else
-  last_rc = fujinet_get_adapter_config(response);
-  return (AdapterConfig *)response;
+  AdapterConfig* ac = (AdapterConfig*)response;
+  last_rc = fujinet_get_adapter_config(ac);
+  return ac;
 #endif
 }
 

--- a/src/rc2014/screen.c
+++ b/src/rc2014/screen.c
@@ -17,7 +17,7 @@
 #define STATUS_BAR 20
 
 extern bool copy_mode;
-extern char copy_host_name;
+extern char copy_host_name[32];
 extern unsigned char copy_host_slot;
 extern bool deviceEnabled[8];
 


### PR DESCRIPTION
Since we use the zsdcc compiler in the libraries, the default use of the sccz80 for fnconfig causes regressions. Fix this by enforcing use of zsdcc and correcting the resulting compilation issues.