### PR TITLE
ATARI: Use fn_io.lib extended adapter config and remove custom MAC/P printing routines

### DIFF
--- a/src/atari/io.c
+++ b/src/atari/io.c
@@ -16,7 +16,7 @@
 #include "fn_io.h"
 
 static NetConfig nc;
-static AdapterConfig adapterConfig;
+static AdapterConfigExtended adapterConfig;
 static SSIDInfo ssidInfo;
 NewDisk newDisk;
 unsigned char wifiEnabled=true;
@@ -101,9 +101,9 @@ SSIDInfo *io_get_scan_result(unsigned char n)
   return &ssidInfo;
 }
 
-AdapterConfig *io_get_adapter_config(void)
+AdapterConfigExtended *io_get_adapter_config(void)
 {
-  fn_io_get_adapter_config(&adapterConfig);
+  fn_io_get_adapter_config_extended(&adapterConfig);
   return &adapterConfig;
 }
 

--- a/src/atari/io.h
+++ b/src/atari/io.h
@@ -18,7 +18,7 @@ unsigned char io_get_wifi_status(void);
 NetConfig* io_get_ssid(void);
 unsigned char io_scan_for_networks(void);
 SSIDInfo *io_get_scan_result(unsigned char n);
-AdapterConfig *io_get_adapter_config(void);
+AdapterConfigExtended *io_get_adapter_config(void);
 void io_set_ssid(NetConfig *nc);
 void io_get_device_slots(DeviceSlot *d);
 void io_get_host_slots(HostSlot *h);

--- a/src/atari/screen.c
+++ b/src/atari/screen.c
@@ -321,19 +321,7 @@ void screen_set_wifi(AdapterConfigExtended *ac)
   screen_puts(0, 0, "WELCOME TO #FUJINET!");
   screen_puts(0, 22, "SCANNING NETWORKS...");
   screen_puts(0, 2, "MAC Address:");
-  screen_puts(15, 2, ":");
-  screen_puts(18, 2, ":");
-  screen_puts(21, 2, ":");
-  screen_puts(24, 2, ":");
-  screen_puts(27, 2, ":");
-
-  // screen_set_wifi_display_mac_address(ac);
-  for (i = 0; i < 6; i++)
-  {
-    itoa(ac->macAddress[i], mactmp, 16);
-    screen_puts(x, 2, mactmp);
-    x += 3;
-  }
+  screen_puts(13, 2, ac->sMacAddress);
 }
 
 void screen_set_wifi_print_rssi(SSIDInfo *s, unsigned char i)

--- a/src/atari/screen.c
+++ b/src/atari/screen.c
@@ -308,7 +308,7 @@ void screen_mount_and_boot()
   bar_clear(false);
 }
 
-void screen_set_wifi(AdapterConfig *ac)
+void screen_set_wifi(AdapterConfigExtended *ac)
 {
   char mactmp[3];
   unsigned char i = 0;
@@ -389,59 +389,11 @@ void screen_set_wifi_password(void)
   screen_puts(3, 22, "   ENTER PASSWORD");
 }
 
-void screen_print_ip(unsigned char x, unsigned char y, unsigned char *buf)
-{
-  unsigned char i = 0;
-  unsigned char tmp[4];
-
-  set_cursor(x, y);
-  for (i = 0; i < 4; i++)
-  {
-    itoa(buf[i], tmp, 10);
-    screen_append(tmp);
-    if (i == 3)
-      break;
-    screen_append(".");
-  }
-}
-
-/**
- * Convert hex to a string and print as a MAC address at position x, y
- */
-void screen_print_mac(unsigned char x, unsigned char y, unsigned char *buf)
-{
-  unsigned char tmp[3];
-  unsigned char i = 0;
-
-  set_cursor(x, y);
-
-  for (i = 0; i < 6; i++)
-  {
-      itoa_hex(buf[i], tmp);
-      screen_append(tmp);
-      if (i == 5) 
-        break;
-      screen_append(":");
-  }
-}
-
-/**
- * Convert hex to a string.  Special hex output of numbers under 16, e.g. 9 -> 09, 10 -> 0A
- */
-void itoa_hex(unsigned char val, char *buf)
-{
-
-  if (val < 16)
-  {
-    *(buf++) = '0';
-  }
-  itoa(val, buf, 16);
-}
 
 /*
  * Display the 'info' screen
  */
-void screen_show_info(int printerEnabled, AdapterConfig *ac)
+void screen_show_info(int printerEnabled, AdapterConfigExtended *ac)
 {
   screen_dlist_show_info();
   set_active_screen(SCREEN_SHOW_INFO);
@@ -464,12 +416,12 @@ void screen_show_info(int printerEnabled, AdapterConfig *ac)
 
   screen_puts(17, 7, ac->ssid);
   screen_puts(17, 8, ac->hostname);
-  screen_print_ip(17, 9, ac->localIP);
-  screen_print_ip(17, 10, ac->gateway);
-  screen_print_ip(17, 11, ac->dnsIP);
-  screen_print_ip(17, 12, ac->netmask);
-  screen_print_mac(17, 13, ac->macAddress);
-  screen_print_mac(17, 14, ac->bssid);
+  screen_puts(17, 9, ac->sLocalIP);
+  screen_puts(17, 10, ac->sGateway);
+  screen_puts(17, 11, ac->sDnsIP);
+  screen_puts(17, 12, ac->sNetmask);
+  screen_puts(17, 13, ac->sMacAddress);
+  screen_puts(17, 14, ac->sBssid);
   screen_puts(17, 15, ac->fn_version);
 }
 

--- a/src/atari/screen.h
+++ b/src/atari/screen.h
@@ -38,9 +38,6 @@ void screen_dlist_select_file(void);
 void screen_dlist_set_wifi(void);
 void screen_dlist_mount_and_boot(void);
 void screen_dlist_select_slot(void);
-void screen_print_ip(unsigned char x, unsigned char y, unsigned char *buf);
-void screen_print_mac(unsigned char x, unsigned char y, unsigned char *buf);
-void itoa_hex(unsigned char val, char *buf);
 void screen_clear(void);
 void set_wifi_print_rssi(SSIDInfo *s, unsigned char i);
 // void screen_set_wifi_display_mac_address(AdapterConfig *adapterConfig);
@@ -55,7 +52,7 @@ void screen_error(const char *msg);
 void screen_init(void);
 void screen_error(const char *c);
 
-void screen_set_wifi(AdapterConfig *ac);
+void screen_set_wifi(AdapterConfigExtended *ac);
 void screen_set_wifi_display_ssid(char n, SSIDInfo *s);
 void screen_set_wifi_select_network(unsigned char nn);
 void screen_set_wifi_custom(void);
@@ -78,7 +75,7 @@ void screen_hosts_and_devices_host_slot_empty(unsigned char hs);
 
 void screen_hosts_and_devices_long_filename(char *f);
 
-void screen_show_info(int printerEnabled, AdapterConfig *ac);
+void screen_show_info(int printerEnabled, AdapterConfigExtended *ac);
 
 void screen_select_file(void);
 void screen_select_file_display(char *p, char *f);


### PR DESCRIPTION
This change requires the FN to be running the latest PlatformIO code that fetches extended adapter information for the wifi, and returns the MAC/IP addresses in string format as well as binary.

Overall reduces app size by 536 bytes.