### PR TITLE
Add enhanced line editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,5 @@ dist/rautoans.com
 dist/rbaudlok.com
 dist/rlisten.com
 dist/rsniff.com
+Makefile.options
 obj

--- a/Makefile.options
+++ b/Makefile.options
@@ -1,1 +1,0 @@
-_OPTIONS_=labelfile,listing

--- a/src/atari/asminc/cfg-constants.inc
+++ b/src/atari/asminc/cfg-constants.inc
@@ -1,0 +1,26 @@
+.ifndef ATESC
+    .include    "atari.inc"
+.endif
+
+CFK_ESC     = ATESC         ; Escape
+CFK_ENTER   = ATEOL         ; Return/Enter
+CFK_TAB     = ATTAB         ; Tab
+CFK_BS      = ATRUB         ; Backspace
+CFK_DEL     = ATDEL         ; Delete
+CFK_INS     = ATINS         ; Insert
+CFK_LEFT    = ATLRW         ; Left Arrow
+CFK_LEFT2   = $2B           ; Left Arrow   Alt "+"
+CFK_RIGHT   = ATRRW         ; Right Arrow
+CFK_RIGHT2  = $2A           ; Right Arrow  Alt "*" 
+CFK_UP      = ATURW         ; Up Arrow
+CFK_UP2     = $2D           ; Up Arrow     Alt "-"
+CFK_DOWN    = ATDRW         ; Down Arrow
+CFK_DOWN2   = $3D           ; Down Arrow   Alt "="
+CFK_ASCIIL  = $20           ; Lowest ASCII code inclusive considered normal key press
+CFK_ASCIIH  = $7D           ; Highest ASCII code inclusive considered normal key press
+CFK_HOME    = $01           ; ctrl-a, start of line char
+CFK_END     = $05           ; ctrl-e, end of line char
+CFK_KILL    = $0B           ; ctrl-k, kill to end of line
+CFK_PARENT  = $3C           ; "<" used in files to go to parent dir
+CFK_FILTER  = $46           ; "F" Filter
+CFK_FILTER2 = $66           ; "f" Filter

--- a/src/atari/asminc/cfg-macros.inc
+++ b/src/atari/asminc/cfg-macros.inc
@@ -195,3 +195,49 @@ dec_hi:
     .endif
 l1:
 .endmacro
+
+; use CA65 function calling conventions, passing values into SP via pushax
+.macro pushax arg1
+    .if (.match (.left (1, {arg1}), #))
+        lda     #<(.right (.tcount ({arg1})-1, {arg1}))
+        ldx     #>(.right (.tcount ({arg1})-1, {arg1}))
+        jsr     pushax
+    .else
+        lda     arg1
+        ldx     1+(arg1)
+        jsr     pushax
+    .endif
+.endmacro
+
+; push arg1 into SP from A
+.macro pusha arg1
+    lda     arg1
+    jsr     pusha
+.endmacro
+
+; same as pushax, but without the push to SP, preparing the args directly for consumption
+.macro setax arg1
+    .if (.match (.left (1, {arg1}), #))
+        lda     #<(.right (.tcount ({arg1})-1, {arg1}))
+        ldx     #>(.right (.tcount ({arg1})-1, {arg1}))
+    .else
+        lda     arg1
+        ldx     1+(arg1)
+    .endif
+.endmacro
+
+.macro popax arg1
+    jsr     popax
+    sta     arg1
+    stx     1+(arg1)
+.endmacro
+
+.macro popa arg1
+    jsr     popa
+    sta     arg1
+.endmacro
+
+.macro axinto arg1
+    sta     arg1
+    stx     1+(arg1)
+.endmacro

--- a/src/atari/edit_line.s
+++ b/src/atari/edit_line.s
@@ -1,0 +1,435 @@
+        .export     _edit_line
+
+        ; we will reuse this 256 byte buffer that is only used for copying disks, so quite a chunk that's hardly ever used
+
+        .import     _cgetc
+        .import     _copySpec
+        .import     _cursor_ptr
+        .import     _set_cursor
+        .import     _strlen
+        .import     _strncpy
+        .import     popa
+        .import     popax
+        .import     pusha
+        .import     pushax
+        .import     return0
+        .import     return1
+
+        .include    "atari.inc"
+        .include    "zeropage.inc"
+        .include    "cfg-macros.inc"
+        .include    "cfg-constants.inc"
+
+; int edit_line(unsigned char x, unsigned char y, char *s, unsigned char maxlen)
+
+; re-implementation of edit_line
+; returns 1 if there was an edit, 0 if there was none.
+.proc _edit_line
+        sta     el_max_len          ; max length for editing
+        popax   el_str              ; the original string being edit
+        popa    el_y
+        popa    el_x
+
+        ; copy the src string into our buffer _copySpec
+        pushax  #_copySpec          ; dst
+        pushax  el_str              ; src
+        ldx     #$00
+        lda     el_max_len
+        jsr     _strncpy
+
+        ; get x,y coordinate on screen into _cursor_ptr
+        pusha   el_x
+        lda     el_y
+        jsr     _set_cursor
+
+        ; setup initial length variables
+        setax   el_str
+        jsr     _strlen
+        sta     el_buf_len
+        sta     el_crs_idx
+        ; if length of string we initially edit is at max, need to fix cursor position slightly
+        jsr     cap_cursor
+
+        mwa     _cursor_ptr, ptr4   ; the holy ptr4 screen location
+
+        ; check if the target string is empty, and clear edit area if it is
+        ldy     #$00
+        lda     _copySpec
+        bne     :+
+        jsr     clear_edit          ; clears any <Empty> type text
+
+        ; initialise cursor at end of string
+:       ldy     el_crs_idx
+        lda     (ptr4), y
+        eor     #$80
+        sta     (ptr4), y
+
+        mwa     #_copySpec, ptr3
+
+        lda     el_max_len
+        sec
+        sbc     #$02
+        sta     el_max_len_min2         ; required for some end of cursor checks
+
+        ; from now on
+        ;   ptr3 = target location of copy string we are editing (_copySpec)
+        ;   ptr4 = _cursor_ptr
+
+keyboard_loop:
+        ; jsr     _kb_get_c
+        jsr     _cgetc
+        cmp     #$00
+        beq     keyboard_loop
+
+        ldy     el_crs_idx
+
+; ---------------------------------
+; ESC
+        cmp     #CFK_ESC
+        bne     not_esc
+
+        ; abandon edits, and show original string in edit area
+        jsr     clear_edit
+        mwa     el_str, ptr1
+        jsr     put_ptr1_s
+        jmp     return0
+
+not_esc:
+; ---------------------------------
+; BACKSPACE
+        cmp     #CFK_BS
+        bne     not_bs
+
+        ; y is cursor index, don't allow if it's 0
+        cpy     #$00
+        beq     keyboard_loop
+
+        ; move all bytes up to end of line down 1 position
+:       lda     (ptr3), y
+        dey
+        sta     (ptr3), y
+        iny
+        iny
+        cpy     el_max_len
+        bne     :-
+
+        ; put a zero at the end
+        dey
+        mva     #$00, {(ptr3), y}
+
+        ; reduce edit index and buffer length
+        dec     el_crs_idx
+        dec     el_buf_len
+        jsr     refresh_line
+        jmp     keyboard_loop
+
+not_bs:
+
+; --------------------------------------------------------------------------
+; DELETE
+        cmp     #CFK_DEL
+        bne     not_del
+
+        ; check if cursor is not at the end first. if it is, nothing to do
+        lda     el_crs_idx
+        cmp     el_buf_len
+        bcc     can_del
+        bcs     keyboard_loop   ; can't delete as there is nothing ahead of us
+
+can_del:
+        ; move bytes forward of ourselves down a position
+        iny
+:       lda     (ptr3), y
+        dey
+        sta     (ptr3), y
+        iny
+        iny
+        cpy     el_max_len
+        bne     :-
+
+        ; put a zero at the end
+        dey
+        mva     #$00, {(ptr3), y}
+
+        ; reduce sbuffer length
+        dec     el_buf_len
+        jsr     refresh_line
+        jmp     keyboard_loop
+
+not_del:
+
+; --------------------------------------------------------------------------
+; INSERT
+        cmp     #CFK_INS
+        bne     not_insert
+
+        ; check if cursor is at end, do nothing if it is
+        lda     el_crs_idx
+        cmp     el_buf_len
+        bcc     can_ins
+        bcs     keyboard_loop
+
+can_ins:
+        ; push everything forward 1 char, up to end of buffer.
+        ; string is always terminated up to end of buffer with zeroes due to initial strncpy
+        ; last char if there was one, drops off end if string too big.
+        ; put space in current location
+        ; set y = max_len - 2 (one off for null, one off for not going too far)
+        ldy     el_max_len
+        dey
+        dey
+
+:       lda     (ptr3), y       ; load char from end, push it forward one, down to current position
+        iny
+        sta     (ptr3), y
+        dey
+        dey
+        bmi     :+              ; were we editing at position 0? TODO: will this break with long strings?
+        cpy     el_crs_idx
+        bcs     :-
+
+        ; put space at our current location, y is 1 less than cursor location at moment
+:       iny
+        mva     #' ', {(ptr3), y}
+
+        ; put 0 at end to ensure string is always nul terminated
+        ldy     el_max_len
+        dey
+        mva     #$00, {(ptr3), y}
+
+        ; increase buffer len if we can
+        mva     el_max_len_min2, tmp1
+        lda     el_buf_len
+        cmp     tmp1
+        bcs     no_extra
+        inc     el_buf_len
+
+no_extra:
+        jsr     refresh_line
+        jmp     keyboard_loop
+
+not_insert:
+
+; --------------------------------------------------------------------------
+; LEFT CURSOR
+        cmp     #CFK_LEFT
+        bne     not_left
+
+        ; if cursor already at 0, don't move
+        lda     el_crs_idx
+        cmp     #$00
+        beq     :+
+
+        dec     el_crs_idx
+        jsr     refresh_line
+
+:
+        jmp     keyboard_loop
+
+not_left:
+
+; --------------------------------------------------------------------------
+; RIGHT CURSOR
+        cmp     #CFK_RIGHT
+        bne     not_right
+
+        ; if cursor already at max, don't move.
+        mva     el_max_len_min2, tmp1
+        lda     el_crs_idx
+        cmp     tmp1
+
+        beq     :+
+        ; also can't be longer than the current buffer length
+        cmp     el_buf_len
+        bcs     :+
+
+        ; allowed to move cursor as it isn't at the ends
+        inc     el_crs_idx
+
+:       jsr     refresh_line
+        jmp     keyboard_loop
+
+not_right:
+
+; --------------------------------------------------------------------------
+; HOME
+        cmp     #CFK_HOME
+        bne     not_home
+
+        ; set cursor to 0
+        mva     #$00, el_crs_idx
+        jsr     refresh_line
+        jmp     keyboard_loop
+
+not_home:
+
+; --------------------------------------------------------------------------
+; END
+        cmp     #CFK_END
+        bne     not_end_key
+
+        ; set cursor to buf len (end of editing buffer)
+        mva     el_buf_len, el_crs_idx
+        jsr     cap_cursor
+
+        jsr     refresh_line
+        jmp     keyboard_loop
+
+not_end_key:
+
+; --------------------------------------------------------------------------
+; KILL
+        cmp     #CFK_KILL ; kill text to end of buffer
+        bne     not_kill
+
+        lda     #$00
+:       sta     (ptr3), y       ; current cursor position forward should become 0s
+        iny
+        cpy     el_max_len
+        bcc     :-
+
+        jsr     refresh_line
+        jmp     keyboard_loop
+
+not_kill:
+
+; --------------------------------------------------------------------------
+; ATASCII CHAR (between CFK_ASCIIL and CFK_ASCIIH inclusive)
+        cmp     #CFK_ASCIIL
+        bcs     space_or_more
+        bcc     not_ascii
+space_or_more:
+        cmp     #CFK_ASCIIH+1
+        bcs     not_ascii
+        sta     tmp1            ; save it while we check bounds
+
+        ; check bounds, if current edit position is on last char, we can't add more
+        ldx     el_max_len
+        dex
+        stx     tmp2
+        cpy     tmp2
+        bcs     :+
+
+        ; ok! save this char to current edit index (y)
+        mva     tmp1, {(ptr3), y}
+
+        ; did we extend the buffer, or overwrite a char?
+        ; we are overwriting if y index is less than buf len
+        cpy     el_buf_len
+        bcc     :+
+        inc     el_buf_len
+
+        ; can we move cursor on? yes if not now at end
+:       mva     el_max_len_min2, tmp1
+        cpy     tmp1
+        beq     :+
+
+        ; allowed to move cursor
+        inc     el_crs_idx
+
+:       jsr     refresh_line
+        jmp     keyboard_loop
+
+not_ascii:
+
+; --------------------------------------------------------------------------
+; ENTER
+        cmp     #CFK_ENTER
+        bne     not_eol
+
+        ; invert the char at edit location to remove cursor
+        lda     (ptr4), y
+        eor     #$80            ; invert high bit only. This is actually always 1->0 as we don't allow inverted chars  
+        sta     (ptr4), y
+
+        ; save the buffer into the original string's memory
+        pushax  el_str          ; dst
+        pushax  ptr3            ; src
+        ldx     #$00
+        lda     el_max_len
+        jsr     _strncpy
+        ; restore screen pointer for print routines
+        mwa     _cursor_ptr, ptr4
+
+end_enter:
+        ; mark that we made an edit, so caller must act appropriately.
+        jmp     return1
+
+not_eol:
+        ; not a char we recognised, go back for next char
+        jmp     keyboard_loop
+
+.endproc
+
+; ensure the cursor isn't beyond bounds
+.proc cap_cursor
+        ; if we're at max-1, put us at max-2 as can't move cursor into last byte
+        ldx     el_max_len
+        dex
+        cpx     el_crs_idx
+        bne     :+
+        dex
+        stx     el_crs_idx
+
+:       rts
+.endproc
+
+.proc put_ptr1_s
+        ldy     #$00
+l1:
+        lda     (ptr1), y
+        beq     out
+
+        ; convert ascii to screen code, from cputc
+        asl     a               ; shift out the inverse bit
+        adc     #$c0            ; grab the inverse bit; convert ATASCII to screen code
+        bpl     codeok          ; screen code ok?
+        eor     #$40            ; needs correction
+codeok: lsr     a               ; undo the shift
+        bcc     :+
+        eor     #$80            ; restore the inverse bit
+
+:       sta     (ptr4), y
+        iny
+        bne     l1
+out:
+        rts
+.endproc
+
+; show current editing string at screen location and show cursor
+.proc refresh_line
+        ; copy buffer to screen memory and deal with last char by blanking whole line out first
+        jsr     clear_edit
+        mwa     ptr3, ptr1
+        jsr     put_ptr1_s
+
+        ; load Y with current location index
+        ldy     el_crs_idx
+
+        ; invert the screen location's char for cursor display, which handles cursor INSIDE a string
+        ; this is visual only, and doesn't affect buffer
+        lda     (ptr4), y
+        ora     #$80
+        sta     (ptr4), y
+        rts
+.endproc
+
+.proc clear_edit
+        lda     #$00    ; screen space
+        ldy     #$00
+:       sta     (ptr4), y
+        iny
+        cpy     el_max_len
+        bne     :-
+        rts
+.endproc
+
+
+.bss
+el_max_len:         .res 1
+el_max_len_min2:    .res 1
+el_str:             .res 2  ; pointer to original string being edit
+el_x:               .res 1
+el_y:               .res 1
+el_crs_idx:         .res 1  ; index in the string of the cursor position
+el_buf_len:         .res 1  ; buffer length, keep track as we make edits so don't have to redo strlen

--- a/src/atari/input.c
+++ b/src/atari/input.c
@@ -92,23 +92,23 @@ void input_line_set_wifi_custom(char *c)
 {
   bar_show(20);
   memset(c, 0, 32);
-  _screen_input(2, 20, c, 32);
+  edit_line(2, 20, c, 32);
 }
 
 void input_line_set_wifi_password(char *c)
 {
   // bar_show(19);
-  _screen_input(0, 21, c, 64);
+  edit_line(0, 21, c, 64);
 }
 
 void input_line_hosts_and_devices_host_slot(unsigned char i, unsigned char o, char *c)
 {
-  _screen_input(5, i + HOSTS_START_Y, c, 32);
+  edit_line(5, i + HOSTS_START_Y, c, 32);
 }
 
 void input_line_filter(char *c)
 {
-  _screen_input(5, 2, c, 32);
+  edit_line(5, 2, c, 32);
 }
 
 unsigned char input_select_file_new_type(void)
@@ -121,7 +121,7 @@ unsigned long input_select_file_new_size(unsigned char t)
 {
   char temp[8];
   memset(temp, 0, sizeof(temp));
-  _screen_input(34, 21, temp, sizeof(temp));
+  edit_line(34, 21, temp, sizeof(temp));
 
   // TODO: make an enum so these are easier to understand
   switch (temp[0])
@@ -157,14 +157,14 @@ unsigned long input_select_file_new_custom(void)
 
   // Number of Sectors
   memset(tmp_str, 0, sizeof(tmp_str));
-  _screen_input(11, 20, tmp_str, sizeof(tmp_str));
+  edit_line(11, 20, tmp_str, sizeof(tmp_str));
   custom_numSectors = atoi(tmp_str);
 
   // Sector Size
   memset(tmp_str, 0, sizeof(tmp_str));
   while (tmp_str[0] != '1' && tmp_str[0] != '2' && tmp_str[0] != '5')
   {
-    _screen_input(27, 21, tmp_str, sizeof(tmp_str));
+    edit_line(27, 21, tmp_str, sizeof(tmp_str));
   }
 
   switch (tmp_str[0])
@@ -187,7 +187,7 @@ unsigned long input_select_file_new_custom(void)
 void input_select_file_new_name(char *c)
 {
   // TODO: Find out actual max length we shoud allow here. Input variable is [128] but do we allow filenames that large?
-  _screen_input(0, 21, c, 128);
+  edit_line(0, 21, c, 128);
 }
 
 bool input_select_slot_build_eos_directory(void)
@@ -317,7 +317,7 @@ HDSubState input_hosts_and_devices_hosts(void)
     // boot lobby.
     memset(temp, 0, sizeof(temp));
     screen_puts(0,24,"Boot Lobby Y/N? ");
-    _screen_input(16,24,temp,2);
+    edit_line(16,24,temp,2);
     screen_clear_line(24);
     switch (temp[0])
     {
@@ -429,7 +429,7 @@ HDSubState input_hosts_and_devices_devices(void)
     // boot lobby.
     memset(temp, 0, sizeof(temp));
     screen_puts(0,24,"Boot Lobby Y/N? ");
-    _screen_input(16,24,temp,2);
+    edit_line(16,24,temp,2);
     screen_clear_line(24);
     switch (temp[0])
     {

--- a/src/atari/screen.c
+++ b/src/atari/screen.c
@@ -208,7 +208,7 @@ void screen_set_wifi_custom(void)
 void screen_set_wifi_password(void)
 {
   screen_clear_line(22);
-  screen_puts(3, 22, "   ENTER PASSWORD");
+  screen_puts(0, 23, "    ENTER PASSWORD");
 }
 
 
@@ -602,18 +602,12 @@ void screen_hosts_and_devices_devices_clear_all(void)
 
 void screen_hosts_and_devices_clear_host_slot(unsigned char i)
 {
-  // i comes in as the place in the array for this host slot. To get the corresponding position on the screen, add HOSTS_START_Y
-  screen_clear_line(i + HOSTS_START_Y);
+  // nothing to do, edit_line handles clearing correct space on screen, and doesn't touch the list numbers
 }
 
 void screen_hosts_and_devices_edit_host_slot(unsigned char i)
 {
-  char tmp[2] = {0, 0};
-  int newloc = i + HOSTS_START_Y;
-
-  screen_clear_line(newloc);
-  tmp[0] = newloc - HOSTS_START_Y + 0x31;
-  screen_puts(2, newloc, tmp);
+  // nothing to do, edit_line handles clearing correct space on screen, and doesn't touch the list numbers
 }
 
 void screen_hosts_and_devices_eject(unsigned char ds)
@@ -763,48 +757,6 @@ void screen_dlist_hosts_and_devices(void)
   POKE(DISPLAY_LIST + 0x1b, DL_CHR40x8x1);
   POKE(DISPLAY_LIST + 0x1c, DL_CHR40x8x1);
 }
-
-int _screen_input(unsigned char x, unsigned char y, char *s, unsigned char maxlen)
-{
-  unsigned char k, o;
-  unsigned char *input_start_ptr;
-
-  o = strlen(s);                // assign to local var the size of s which contains the current string
-  set_cursor(x, y);             // move the cusor to coordinates x,y
-  input_start_ptr = cursor_ptr; // assign the value currently in cursor_ptr to local var input_start
-  screen_append(s);             // call screen_append function and pass by value (a copy) the contents of s
-
-  POKE(cursor_ptr, 0x80); // turn on cursor
-
-  // Start capturing the keyboard input into local var k
-  do
-  {
-    k = cgetc(); // Capture keyboard input into k
-
-    if (k == KCODE_ESCAPE) // KCODE_ESCAPE is the ATASCI code for the escape key which is commonly used to cancel.
-      return -1;
-
-    if (k == KCODE_BACKSP) // KCODE_BACKSP is the ATASCI backspace key.  This if clause test for backspace and updates cursor_ptr to the remainder of contents upto the last backspace
-    {
-      if (cursor_ptr > input_start_ptr) // execute only if cursor_ptr is greater than input_start_ptr
-      {
-        s[--o] = 0;                  //
-        POKEW(--cursor_ptr, 0x0080); // move the last bit of the cursor_ptr back one and write the location of the cursor_ptr contents to user zero page address 0x80
-      }
-    }
-    else if ((k > 0x1F) && (k < 0x80)) // Display printable ascii to screen
-    {
-      if (o < maxlen - 1)
-      {
-        put_char(k);
-        s[o++] = k;
-        POKE(cursor_ptr, 0x80);
-      }
-    }
-  } while (k != KCODE_RETURN); // Continue to capture keyboard input until return (0x9B)
-  POKE(cursor_ptr, 0x00);      // clear cursor
-}
-
 
 #ifdef DEBUG
 // Debugging function to show line #'s, used to test if the Y coordinate calculations are working.

--- a/src/atari/screen.h
+++ b/src/atari/screen.h
@@ -21,18 +21,16 @@ typedef enum
    SCREEN_CONNECT_WIFI
 } _screen;
 
-#define screen_input(x, y, s) _screen_input((x), (y), (s), sizeof(s))
-
 #ifdef DEBUG
 void show_line_nums(void);
 void screen_debug(char *message);
 #endif // DEBUG
 
 void set_cursor(unsigned char x, unsigned char y);
+int edit_line(unsigned char x, unsigned char y, char *s, unsigned char maxlen);
 
 void set_active_screen(unsigned char screen);
 void screen_mount_and_boot();
-int _screen_input(unsigned char x, unsigned char y, char *s, unsigned char maxlen);
 void screen_dlist_connect_wifi(void);
 void screen_dlist_hosts_and_devices(void);
 void screen_dlist_show_info(void);

--- a/src/atari/set_cursor.s
+++ b/src/atari/set_cursor.s
@@ -5,8 +5,6 @@
         .import     _video_ptr
         .import     popa
 
-        .import     _cfg_debug
-
         .include    "zeropage.inc"
         .include    "cfg-macros.inc"
 
@@ -73,7 +71,7 @@ sc_show_info:
     .word 0, 20
     .word 40, 80, 120
     .word 160, 180
-    .word 200, 240, 280, 320, 360, 400, 440, 480, 520, 560, 600, 640, 680, 720, 760, 800
+    .word 200, 240, 280, 320, 360, 400, 440, 480, 520, 560, 600, 640, 680, 720, 760, 800, 840
 
 sc_sel_file:
 sc_sel_slot:

--- a/src/hosts_and_devices.c
+++ b/src/hosts_and_devices.c
@@ -92,6 +92,8 @@ void hosts_and_devices_edit_host_slot(unsigned char i)
     o = strlen((const char *)hostSlots[i]);
 
   screen_hosts_and_devices_edit_host_slot(i);
+  // FRUSTRATINGLY the signature is void return, so noone ever knows if the return was good or bad
+  // and just carries on and saves changes anyway. Fortunately ESC now handled well (on atari) and will save same thing back to FN
   input_line_hosts_and_devices_host_slot(i, o, (char *)hostSlots[i]);
 
   if (strlen((const char*)hostSlots[i]) == 0)

--- a/src/set_wifi.c
+++ b/src/set_wifi.c
@@ -98,6 +98,7 @@ void set_wifi_custom(void)
 void set_wifi_password(void)
 {
   screen_set_wifi_password();
+  screen_puts(0, 21, nc.password);
   input_line_set_wifi_password(nc.password);
   ws_subState=WS_DONE;
 }


### PR DESCRIPTION
This adds a new function "_edit_line" with enhanced cursor control for line editing in config.

I took the routine from new-config, and adjusted it to fit this config.

keys supported:

ctrl-a : beginning of line
ctrl-e : end of line
ctrl-k : kill to end of line
delete : deletes previous char
ctrl-del : deletes char under cursor
ESC : cancel editing
ctrl left/right : move cursor left/right

Escape now restores the previous string that was there.
Unfortunately, non of the signatures of functions that do editing ever react to the return value, and are all void, so ESC as cancel doesn't stop the config from being saved, or entering wifi passwords from stopping the process, but this is a limitation of the current functions, not the editing.