### PR TITLE
Adding page up, page down, and filter to the file browser

### DIFF
--- a/Makefile.coco
+++ b/Makefile.coco
@@ -4,6 +4,7 @@ CC=cmoc
 AS=lwasm
 CP=cp
 ECHO=echo
+FIRMWARE_DIR="../fujinet-firmware"
 
 config.bin: check_wifi.o connect_wifi.o destination_host_slot.o hosts_and_devices.o main.o perform_copy.o select_file.o select_slot.o set_wifi.o show_info.o bar.o die.o input.o io.o mount_and_boot.o screen.o strrchr.o pause.o
 	$(CC) -o config.bin check_wifi.o connect_wifi.o destination_host_slot.o hosts_and_devices.o main.o perform_copy.o select_file.o select_slot.o set_wifi.o show_info.o bar.o die.o input.o io.o mount_and_boot.o screen.o strrchr.o pause.o
@@ -11,8 +12,8 @@ config.bin: check_wifi.o connect_wifi.o destination_host_slot.o hosts_and_device
 	decb dskini autorun.dsk
 	decb copy -t -0 dist.coco/autoexec.bas autorun.dsk,AUTOEXEC.BAS
 	writecocofile autorun.dsk config.bin
-	$(CP) autorun.dsk ~/Workspace/fujinet-firmware/data/webui/device_specific/BUILD_COCO/
-	$(CP) autorun.dsk ~/tnfs/
+	$(CP) autorun.dsk $(FIRMWARE_DIR)/data/webui/device_specific/BUILD_COCO/
+#	$(CP) autorun.dsk ~/tnfs/
 	$(ECHO) Now, Do a Upload Filesystem task.
 
 pause.o: src/coco/pause.c

--- a/src/coco/input.c
+++ b/src/coco/input.c
@@ -166,8 +166,7 @@ void input_line_hosts_and_devices_host_slot(int i, unsigned int o, char *c)
 
 void input_line_filter(char *c)
 {
-  while (true)
-    printf("%c",inkey());
+	input_line(0,15,c,31,false);
 }
 
 unsigned char input_select_file_new_type(void)
@@ -359,9 +358,12 @@ SFSubState input_select_file_choose(void)
 
       switch(k)
 	{
-        case 'N':
-        case 'n':
-            return SF_NEW;
+	case 'F':
+	case 'f':
+	  return SF_FILTER;
+    case 'N':
+    case 'n':
+      return SF_NEW;
 	case 0x03: // BREAK
 	  state = HOSTS_AND_DEVICES;
 	  return SF_DONE;
@@ -377,7 +379,7 @@ SFSubState input_select_file_choose(void)
 	    return SF_LINK;
 	  else
 	    return SF_DONE;
-	case 0x5E:
+	case 0x5E: // up arrow
 	  if ((bar_get() == 0) && (pos > 0))
 	    return SF_PREV_PAGE;
 	  else
@@ -388,9 +390,13 @@ SFSubState input_select_file_choose(void)
 	      select_display_long_filename();
 	      return SF_CHOOSE;
 	    }
-	case 0x0A:
+	case 0x5F: // shifted up arrow
+	  if (pos > 0)
+		return SF_PREV_PAGE;
+	  break;
+	case 0x0A: // down arrow
 	  if ((bar_get() == 9) && (dir_eof==false))
-	    return SF_NEXT_PAGE;
+		return SF_NEXT_PAGE;
 	  else
 	    {
 	      /* long_entry_displayed=false; */
@@ -399,6 +405,10 @@ SFSubState input_select_file_choose(void)
 	      select_display_long_filename();
 	      return SF_CHOOSE;
 	    }
+	  break;
+	case 0x5B: // shifted down arrow
+	  if (dir_eof == false)
+		return SF_NEXT_PAGE;
 	  break;
 	default:
 	  return SF_CHOOSE;

--- a/src/coco/io.c
+++ b/src/coco/io.c
@@ -348,6 +348,7 @@ void io_open_directory(unsigned char hs, char *p, char *f)
 
     memset(odc.p,0,sizeof(odc.p));
     strcpy(odc.p,p);
+    strcpy(&odc.p[strlen(odc.p)+1],filter);
 
     io_ready();
     dwwrite((byte *)&odc, sizeof(odc));

--- a/src/coco/screen.c
+++ b/src/coco/screen.c
@@ -30,7 +30,7 @@ extern HDSubState hd_subState;
 extern DeviceSlot deviceSlots[NUM_DEVICE_SLOTS];
 extern HostSlot hostSlots[8];
 
-static char uppercase_tmp[32]; // temp space for strupr(s) output.
+char uppercase_tmp[32]; // temp space for strupr(s) output.
                                // so original strings doesn't get changed.
 
 char *screen_upper(char *s)
@@ -261,9 +261,11 @@ void screen_select_file_display(char *p, char *f)
 
   if (f[0]==0x00)
       printf("%-32s",screen_upper(p));
-  else
-      printf("%-24s%8s",screen_upper(p),screen_upper(f));
-
+  else {
+      printf("%-24s",screen_upper(p));
+	  locate(24,1);
+	  printf ("%8s",screen_upper(f));
+  }
   screen_add_shadow(2,ORANGE);
 }
 
@@ -277,6 +279,9 @@ void screen_select_file_clear_long_filename(void)
 
 void screen_select_file_filter(void)
 {
+    locate(0,14);
+    printf("%-63s","ENTER FILTER:");
+    locate(0,15);
 }
 
 void screen_select_file_next(void)
@@ -300,7 +305,16 @@ void screen_select_file_display_entry(unsigned char y, const char *e, unsigned e
 void screen_select_file_choose(char visibleEntries)
 {
   locate(0,14);
-  printf("%-32s","left PARENT DIR up/down MOVE");
+  printf("%-32s","_ ../ up/dn MOVE ^up/^dn PAGE");
+  asm {
+	PSHS	B
+	LDB		#$1F
+	STB		$5C0
+	DECB
+	STB		$5D1
+	STB		$5D5
+	PULS	B
+  }
   
   if (copy_mode==true)
     {


### PR DESCRIPTION
File browser functionality changes:
- Added page up/page down facility (shift-up and shift-down arrows)
- Added filter facility
- Fixed filter display bug on file browser header rows
- Updated menu bar to reflect paging option

Quality-of-life changes:
- `Makefile.coco` now has a variable to denote where to put autorun.dsk