### PR TITLE
IIe has no MouseText

### DIFF
--- a/src/apple2/screen.c
+++ b/src/apple2/screen.c
@@ -118,7 +118,7 @@ void screen_init(void)
     {
       allow_lowercase(true);
       lowercase = true;
-      if (get_ostype() >= APPLE_IIE)
+      if (get_ostype() > APPLE_IIE)
       {
         POKE(0xC00F,0); // SETALTCHAR
         mousetext = true;


### PR DESCRIPTION
MouseText didn't arrive until the IIc, the non-enhanced IIe doesn't have it. (See attached pic.)

![FD20B2EE-20CA-4C9F-BB07-774B06D75F5A_1_105_c](https://github.com/user-attachments/assets/85ec05a0-a80a-4875-90e7-f41595cf1eff)
