### PR TITLE
[All Systems] - If a host entry is changed, eject any disks that were mounted from the "old" host since they aren't valid anymore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 2025-12-28
+## 2025-01-01
+
+* [All Systems] - If a host entry is changed, eject any disks that were mounted from the "old" host since they aren't valid anymore.
+
+## 2024-12-28
 
  * [Atari] - Remove unused variables.
 
-## 2025-12-25
+## 2024-12-25
 
  * [Atari] - Upgrade fujinet-lib to 4.7.4
  * [Atari] - Changes to wifi network selection screen to accomodate passwords up to 64 characters in a more consistent visual style. The main password line was set as 40x8x1, but when it wrapped the next line was set to 20x8x2. Shifted down the two larger 20 column lines to leave two 40 column lines for the password.


### PR DESCRIPTION
Based on Thom's Discord reply in `#fujinet-config` on 12/17/2024, "if a host slot is edited, Then any drive slots that use that host slot should be cleared. We should unmount, but that won't be an issue, as the session will inevitably time-out"

I was only able to test on Atari. Since this is in the shared code it would be good to check that it looks ok for the other systems and I didn't break anything.