### PR TITLE
Only consider entry a folder if it ends with /.

### DIFF
--- a/src/select_file.c
+++ b/src/select_file.c
@@ -390,7 +390,7 @@ unsigned select_file_entry_type(void)
 
   e = io_read_directory(128, 0);
 
-  if (strrchr(e, '/') != NULL) result = ENTRY_TYPE_FOLDER;
+  if (e[strlen(e)-1] == '/') result = ENTRY_TYPE_FOLDER;
   else if (e[0] == '+') result = ENTRY_TYPE_LINK;
   else result = ENTRY_TYPE_FILE;
 


### PR DESCRIPTION
Before this PR, if a directory entry contains slash at any position, it'll be considered a folder. After this PR, it must be a trailing slash.