### PR TITLE
Disk slot and host select screen fixes

### DIFF
--- a/src/coco/input.c
+++ b/src/coco/input.c
@@ -289,6 +289,9 @@ HDSubState input_hosts_and_devices_hosts(void)
     case '6':
     case '7':
     case '8':
+      bar_clear(false);
+      bar_jump(k-'1');
+      
       break;
     }
   return HD_HOSTS;
@@ -337,6 +340,7 @@ HDSubState input_hosts_and_devices_devices(void)
     case 0x31:
     case 0x32:
     case 0x33:
+      bar_clear(false);
       bar_jump(k-'0');
       break;
     /* default: */

--- a/src/coco/screen.c
+++ b/src/coco/screen.c
@@ -413,7 +413,7 @@ void screen_hosts_and_devices_devices()
   printf("\x80\x80\x80\x31-8slotEditENTERbrowseLobby\x80\x80\x80\x80\x80\x80\x43onfigTABdrivesBREAKboot\x80\x80\x80");
 
   locate(0,13);
-  printf("1-8 slot Eject  CLEAR  all slots");
+  printf("0-3 slot Eject  CLEAR  all slots");
   printf("<- hosts Read Write Config Lobby");
 
   screen_add_shadow(15,RED);


### PR DESCRIPTION
Coco:  Changed text on the disk slot select screen to indicate 0-3. Changed host select screen to allow user to hit 1-8 to select a host slot as the screen implies.