### PR TITLE
Display fixes to device select screen and disk list after exit

### DIFF
--- a/src/coco/input.c
+++ b/src/coco/input.c
@@ -316,12 +316,12 @@ HDSubState input_hosts_and_devices_devices(void)
     case 'R':
     case 'r':
       selected_device_slot=(byte)bar_get();
-      hosts_and_devices_devices_set_mode(0);
+      hosts_and_devices_devices_set_mode(MODE_READ);
       return HD_DEVICES;
     case 'W':
     case 'w':
       selected_device_slot=(byte)bar_get();
-      hosts_and_devices_devices_set_mode(2);
+      hosts_and_devices_devices_set_mode(MODE_WRITE);
       return HD_DEVICES;
     case 0x03:
       return HD_DONE;

--- a/src/coco/input.c
+++ b/src/coco/input.c
@@ -438,13 +438,13 @@ SSSubState input_select_slot_choose(void)
       break;
     case 0x0d: // ENTER
     case 'R':
-      mode=0;
+      mode=MODE_READ;
       selected_device_slot=(char)bar_get();
       strncpy(source_path,path,224);
       old_pos = pos;
       return SS_DONE;
     case 'W':
-      mode=2;
+      mode=MODE_WRITE;
       selected_device_slot=(char)bar_get();
       return SS_DONE;
     case 0x5E:

--- a/src/hosts_and_devices.c
+++ b/src/hosts_and_devices.c
@@ -183,6 +183,7 @@ void hosts_and_devices_eject(unsigned char ds)
   io_umount_disk_image(ds);
   memset(deviceSlots[ds].file, 0, FILE_MAXLEN);
   deviceSlots[ds].hostSlot = 0xFF;
+  deviceSlots[ds].mode = 0;
   io_put_device_slots(&deviceSlots[0]);
   io_get_device_slots(&deviceSlots[0]);
   screen_hosts_and_devices_eject(ds);
@@ -287,6 +288,10 @@ void hosts_and_devices_devices_set_mode(unsigned char m)
   //screen_hosts_and_devices_devices_selected(selected_device_slot); // Breaks disk order on screen??
   selected_device_slot = 0; // Go back to drive 0 instead
   hosts_and_devices_devices();
+#elif defined(_CMOC_VERSION_)
+    io_mount_disk_image(selected_device_slot, m);
+    screen_hosts_and_devices_device_slots(1,&deviceSlots[0],&deviceEnabled[0]);
+    bar_jump(selected_device_slot);
 #else
     io_mount_disk_image(selected_device_slot, m);
 #endif
@@ -335,7 +340,7 @@ void hosts_and_devices_done(void)
     if (deviceSlots[i].hostSlot != 0xFF)
     {
 #ifdef _CMOC_VERSION_
-      printf("%d:%s\n",i,deviceSlots[i].file);
+      printf("%d:%s\n",i,strupr(deviceSlots[i].file));
 #endif
 #ifdef BUILD_APPLE2
       s = i + 1;


### PR DESCRIPTION
Ensure that Read and Write change shows immediately on disk slot screen.  Ensure that read/write state indicators are cleared when unmounting one or all drives.  Ensure that the mounted disk filenames on exit are all in uppercase (no reverse characters).