### PR TITLE
Create ci.yml github workflow to build artifacts for PR

### DIFF
--- a/.github/.dir-locals.el
+++ b/.github/.dir-locals.el
@@ -1,0 +1,1 @@
+((fundamental-mode . ((indent-tabs-mode . nil))))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - adam
+          - apple2
+          - atari
+          - c64
+          - coco
+          # - msdos # MSDOS doesn't seem to build yet
+
+    container:
+      image: fozztexx/defoogi:1.4.1
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: make -f Makefile.${{ matrix.platform }} r2r
+
+      - name: Upload artifact for ${{ matrix.platform }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform }}
+          path: r2r/${{ matrix.platform }}/**

--- a/Makefile.adam
+++ b/Makefile.adam
@@ -2,12 +2,14 @@ TARGET_EXEC ?= autorun.ddp
 
 BUILD_DIR ?= ./build
 SRC_DIRS ?= ./src
+R2R_DIR ?= ./r2r/adam
+R2R_BIN := $(R2R_DIR)/$(TARGET_EXEC)
 
 ADDL_DIR1 := ../eoslib/src
 ADDL_DIR2 := ../smartkeyslib/src
 
-ADDL_LIB1 := ../eoslib/eos.lib
-ADDL_LIB2 := ../smartkeyslib/smartkeys.lib
+ADDL_LIB1 := eos.lib
+ADDL_LIB2 := smartkeys.lib
 
 CC=zcc
 AS=zcc
@@ -17,15 +19,22 @@ OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
 CFLAGS=+coleco -subtype=adam -DBUILD_ADAM -I$(ADDL_DIR1) -I$(ADDL_DIR2) 
-LDFLAGS=+coleco -subtype=adam -create-app -o$(TARGET_EXEC) -lndos -l$(ADDL_LIB1) -l$(ADDL_LIB2)
+LDFLAGS=+coleco -subtype=adam -create-app -lndos -l$(ADDL_LIB1) -l$(ADDL_LIB2)
 ASFLAGS=+coleco -subtype=adam
 
 INC_DIRS := $(shell find $(SRC_DIRS) -type d)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 
-$(BUILD_DIR)/$(TARGET_EXEC): $(OBJS)
-	$(CC) $(LDFLAGS) $(OBJS)
-	cp autorun.ddp ../fujinet-firmware/data/webui/device_specific/BUILD_ADAM/
+$(R2R_BIN): $(OBJS) | $(R2R_DIR)
+	$(CC) -o$@ $(LDFLAGS) $(OBJS)
+
+.PHONY: dist autorun clean r2r
+
+dist: $(R2R_BIN)
+	cp $< ../fujinet-platformio/data/webui/device_specific/BUILD_ADAM/
+
+# Create the "Ready 2 Run" executable/disk
+r2r: $(R2R_BIN)
 
 # c source
 $(BUILD_DIR)/%.c.o: %.c
@@ -37,10 +46,11 @@ $(BUILD_DIR)/%.asm.o: %.asm
 	$(MKDIR_P) $(dir $@)
 	$(AS) $(ASFLAGS) -c $< -o $@
 
-.PHONY: clean
+$(R2R_DIR):
+	$(MKDIR_P) $@
 
 clean:
-	$(RM) -r autorun* $(BUILD_DIR)
+	$(RM) -r autorun* $(BUILD_DIR) $(R2R_DIR)
 
 -include $(DEPS)
 

--- a/Makefile.apple2
+++ b/Makefile.apple2
@@ -17,6 +17,8 @@ FUJINET_LIB_VERSION_DIR = $(FUJINET_LIB)/$(FUJINET_LIB_VERSION)-$(TARGETS)
 # Name of the final, single-file executable.
 # Default: name of the current dir with target name appended
 PROGRAM := config
+R2R_DIR := r2r/$(TARGETS)
+DISK := $(R2R_DIR)/autorun.po
 
 # Path(s) to additional libraries required for linking the program
 # Use only if you don't want to place copies of the libraries in SRCDIR
@@ -256,7 +258,7 @@ ASFLAGS += --asm-include-dir src/$(TARGETLIST)/asminc --asm-include-dir $(FUJINE
 CFLAGS += --include-dir $(FUJINET_LIB_VERSION_DIR) -DUSING_FUJINET_LIB
 
 .SUFFIXES:
-.PHONY: all test clean get_fujinet_lib zap love
+.PHONY: all test clean get_fujinet_lib zap love dist r2r
 
 all: get_fujinet_lib $(PROGRAM)
 
@@ -316,6 +318,9 @@ get_fujinet_lib:
 $(TARGETOBJDIR):
 	$(call MKDIR,$@)
 
+$(R2R_DIR):
+	$(call MKDIR,$@)
+
 vpath %.c $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
 
 $(TARGETOBJDIR)/%.o: %.c | $(TARGETOBJDIR)
@@ -344,23 +349,28 @@ test: $(PROGRAM)
 	$(EMUCMD) $<
 	$(POSTEMUCMD)
 
-dist: $(PROGRAM)
-	cp dist.apple2/bootable.po dist.apple2/dist.po
-	./dist.apple2/add-file.sh dist.apple2/dist.po config config.system
+$(DISK): $(PROGRAM) | $(R2R_DIR)
+	cp dist.apple2/bootable.po $@
+	./dist.apple2/add-file.sh $@ config config.system
+
+dist: $(DISK)
 	@( \
-    echo "Attempting to copy autorun.po to firmware folder outside of project" ; \
+    echo "Attempting to copy $(DISK) to firmware folder outside of project" ; \
     if [ -d ../fujinet-firmware/ ] ; then \
       echo "Copying into ../fujinet-firmware" ; \
-      cp dist.apple2/dist.po ../fujinet-firmware/data/webui/device_specific/BUILD_APPLE/autorun.po ; \
+      cp dist.apple2/dist.po ../fujinet-firmware/data/webui/device_specific/BUILD_APPLE/$(DISK) ; \
     elif [ -d ../fujinet-platformio/ ] ; then \
       echo "Copying into ../fujinet-platformio (NOTE: please consider renaming to updated fujinet-firmware name)" ; \
-      cp dist.apple2/dist.po ../fujinet-platformio/data/webui/device_specific/BUILD_APPLE/autorun.po ; \
+      cp dist.apple2/dist.po ../fujinet-platformio/data/webui/device_specific/BUILD_APPLE/$(DISK) ; \
     else \
-      echo "ERROR: Could not find fujinet firmware folder to copy autorun.po to." ; \
+      echo "ERROR: Could not find fujinet firmware folder to copy $(DISK) to." ; \
       echo "Tried ../fujinet-firmware, and ../fujinet-platformio" ; \
       exit 1 ; \
     fi ; \
 	)
+
+# Create the "Ready 2 Run" executable/disk
+r2r: get_fujinet_lib $(DISK)
 
 gendebug: $(PROGRAM)
 	@echo "Generating debug.scr script for AppleWin"
@@ -375,7 +385,7 @@ clean:
 	$(call RMFILES,$(REMOVES))
 	$(call RMFILES,$(PROGRAM))
 	$(call RMFILES,*.map)
-	rm -rf dist/
+	rm -rf dist/ $(R2R_DIR)
 
 else # $(words $(TARGETLIST)),1
 

--- a/Makefile.atari
+++ b/Makefile.atari
@@ -18,6 +18,8 @@ FUJINET_LIB_VERSION_DIR = $(FUJINET_LIB)/$(FUJINET_LIB_VERSION)-$(TARGETS)
 # Name of the final, single-file executable.
 # Default: name of the current dir with target name appended
 PROGRAM := config
+R2R_DIR := r2r/$(TARGETS)
+R2R_BIN := $(R2R_DIR)/autorun.atr
 
 # Path(s) to additional libraries required for linking the program
 # Use only if you don't want to place copies of the libraries in SRCDIR
@@ -284,7 +286,7 @@ ASFLAGS += --asm-include-dir src/$(TARGETLIST)/asminc --asm-include-dir $(FUJINE
 CFLAGS += --include-dir $(FUJINET_LIB_VERSION_DIR) -DUSING_FUJINET_LIB
 
 .SUFFIXES:
-.PHONY: all test clean get_fujinet_lib zap
+.PHONY: all test clean get_fujinet_lib zap r2r
 
 all: get_fujinet_lib $(PROGRAM)
 
@@ -344,6 +346,9 @@ get_fujinet_lib:
 $(TARGETOBJDIR):
 	$(call MKDIR,$@)
 
+$(R2R_DIR):
+	$(call MKDIR,$@)
+
 vpath %.c $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
 
 $(TARGETOBJDIR)/%.o: %.c | $(TARGETOBJDIR)
@@ -357,6 +362,9 @@ $(TARGETOBJDIR)/%.o: %.s | $(TARGETOBJDIR)
 $(PROGRAM): $(CONFIG) $(OBJECTS) $(LIBS)
 	$(CC) -t $(CC65TARGET) $(LDFLAGS) -o $@ $(patsubst %.cfg,-C %.cfg,$^)
 
+# Create the "Ready 2 Run" executable/disk
+r2r: get_fujinet_lib $(R2R_BIN)
+
 test: $(PROGRAM)
 	$(PREEMUCMD)
 	$(EMUCMD) $<
@@ -364,26 +372,28 @@ test: $(PROGRAM)
 
 test-atr: $(PROGRAM) dist
 	$(PREEMUCMD) \
-  $(EMUCMD) //disk autorun.atr \
+  $(EMUCMD) //disk $(R2R_BIN) \
 	$(POSTEMUCMD)
 
-dist: $(PROGRAM)
+$(R2R_BIN): $(PROGRAM) | $(R2R_DIR)
 	mkdir -p dist
 	cp ../fujinet-tools/atari/dist/*.COM dist/ || true
 	cp ../fujinet-tools/atari/dist/*.com dist/ || true
 	cp $(PROGRAM) dist/
-	dir2atr -m -S -B picoboot.bin autorun.atr dist/
+	dir2atr -m -S -B picoboot.bin $@ dist/
+
+dist: $(R2R_BIN)
 
 dist-z: $(PROGRAM)
 	@if [ -d "../fujinet-config-loader" ] ; then \
-    echo "Found fujinet-config-loader, creating compressed autorun.atr"; \
+    echo "Found fujinet-config-loader, creating compressed $(R2R_BIN)"; \
     $(MAKE) -C ../fujinet-config-loader clean dist > /dev/null 2>&1 ; \
     if [ $$? -ne 0 ] ; then \
       echo "ERROR running compressor"; \
       exit 1; \
     fi; \
-    cp ../fujinet-config-loader/autorun-zx0.atr ./autorun.atr; \
-    echo "Compressed file saved as autorun.atr"; \
+    cp ../fujinet-config-loader/autorun-zx0.atr ./$(R2R_BIN); \
+    echo "Compressed file saved as $(R2R_BIN)"; \
   else \
     echo "ERROR: Could not find fujinet-config-loader in sibling directory to current."; \
     exit 1; \

--- a/Makefile.c64
+++ b/Makefile.c64
@@ -18,6 +18,8 @@ FUJINET_LIB_VERSION_DIR = $(FUJINET_LIB)/$(FUJINET_LIB_VERSION)-$(TARGETS)
 # Name of the final, single-file executable.
 # Default: name of the current dir with target name appended
 PROGRAM := config
+R2R_DIR := r2r/$(TARGETS)
+R2R_BIN := $(R2R_DIR)/$(PROGRAM).prg
 
 # Path(s) to additional libraries required for linking the program
 # Use only if you don't want to place copies of the libraries in SRCDIR
@@ -260,7 +262,7 @@ ASFLAGS += --asm-include-dir src/$(TARGETLIST)/asminc --asm-include-dir $(FUJINE
 CFLAGS += --include-dir $(FUJINET_LIB_VERSION_DIR) -DUSING_FUJINET_LIB
 
 .SUFFIXES:
-.PHONY: all test clean get_fujinet_lib zap
+.PHONY: all test clean get_fujinet_lib zap r2r
 
 all: get_fujinet_lib $(PROGRAM)
 
@@ -320,6 +322,9 @@ get_fujinet_lib:
 $(TARGETOBJDIR):
 	$(call MKDIR,$@)
 
+$(R2R_DIR):
+	$(call MKDIR,$@)
+
 vpath %.c $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
 
 $(TARGETOBJDIR)/%.o: %.c | $(TARGETOBJDIR)
@@ -330,8 +335,11 @@ vpath %.s $(SRCDIR)/$(TARGETLIST) $(SRCDIR)
 $(TARGETOBJDIR)/%.o: %.s | $(TARGETOBJDIR)
 	$(CC) -t $(CC65TARGET) -c --create-dep $(@:.o=.d) $(ASFLAGS) -o $@ $<
 
-$(PROGRAM): $(CONFIG) $(OBJECTS) $(LIBS)
+$(R2R_BIN): $(CONFIG) $(OBJECTS) $(LIBS) | $(R2R_DIR)
 	$(CC) -t $(CC65TARGET) $(LDFLAGS) -o $@ $(patsubst %.cfg,-C %.cfg,$^)
+
+# Create the "Ready 2 Run" executable/disk
+r2r: get_fujinet_lib $(R2R_BIN)
 
 test: $(PROGRAM)
 	$(PREEMUCMD)

--- a/Makefile.coco
+++ b/Makefile.coco
@@ -5,16 +5,31 @@ AS=lwasm
 CP=cp
 ECHO=echo
 FIRMWARE_DIR="../fujinet-firmware"
+TARGET_EXEC=config.bin
+DISK=autorun.dsk
+R2R_DIR=r2r/coco
+R2R_BIN=$(R2R_DIR)/$(DISK)
 
-config.bin: check_wifi.o connect_wifi.o destination_host_slot.o hosts_and_devices.o main.o perform_copy.o select_file.o select_slot.o set_wifi.o show_info.o bar.o die.o input.o io.o mount_and_boot.o screen.o strrchr.o pause.o
-	$(CC) -o config.bin check_wifi.o connect_wifi.o destination_host_slot.o hosts_and_devices.o main.o perform_copy.o select_file.o select_slot.o set_wifi.o show_info.o bar.o die.o input.o io.o mount_and_boot.o screen.o strrchr.o pause.o
-	$(RM) autorun.dsk
-	decb dskini autorun.dsk
-	decb copy -t -0 dist.coco/autoexec.bas autorun.dsk,AUTOEXEC.BAS
-	writecocofile autorun.dsk config.bin
-	$(CP) autorun.dsk $(FIRMWARE_DIR)/data/webui/device_specific/BUILD_COCO/
-#	$(CP) autorun.dsk ~/tnfs/
+$(TARGET_EXEC): check_wifi.o connect_wifi.o destination_host_slot.o hosts_and_devices.o main.o perform_copy.o select_file.o select_slot.o set_wifi.o show_info.o bar.o die.o input.o io.o mount_and_boot.o screen.o strrchr.o pause.o
+	$(CC) -o $@ check_wifi.o connect_wifi.o destination_host_slot.o hosts_and_devices.o main.o perform_copy.o select_file.o select_slot.o set_wifi.o show_info.o bar.o die.o input.o io.o mount_and_boot.o screen.o strrchr.o pause.o
+
+$(R2R_BIN): $(TARGET_EXEC) | $(R2R_DIR)
+	$(RM) $@
+	decb dskini $@
+	decb copy -t -0 dist.coco/autoexec.bas $@,AUTOEXEC.BAS
+	writecocofile $@ $<
+
+dist: $(R2R_BIN)
+	$(CP) $< $(FIRMWARE_DIR)/data/webui/device_specific/BUILD_COCO/
 	$(ECHO) Now, Do a Upload Filesystem task.
+
+.PHONY: r2r
+
+# Create the "Ready 2 Run" executable/disk
+r2r: $(R2R_BIN)
+
+$(R2R_DIR):
+	mkdir -p $@
 
 pause.o: src/coco/pause.c
 	$(CC) -c src/coco/pause.c
@@ -73,5 +88,5 @@ screen.o: src/coco/screen.c
 clean:
 	$(RM) *.o
 	$(RM) coco/*.o
-	$(RM) config.bin
-	$(RM) autorun.dsk
+	$(RM) $(TARGET_EXEC)
+	$(RM) $(DISK)

--- a/Makefile.msdos
+++ b/Makefile.msdos
@@ -1,4 +1,7 @@
 TARGET  = config.com
+R2R_DIR = r2r/msdos
+R2R_BIN = $(R2R_DIR)/$(TARGET)
+
 CC      = wcc
 CFLAGS  = -q -0 -bt=dos -ms -osh $(CPPFLAGS) -i=src -i=src/msdos 
 
@@ -10,8 +13,14 @@ SOURCE	= src/check_wifi.c src/connect_wifi.c src/destination_host_slot.c src/hos
 
 all:	$(TARGET)
 
-$(TARGET): $(OBJS)
+# Create the "Ready 2 Run" executable/disk
+r2r: $(R2R_BIN)
+
+$(R2R_BIN): $(OBJS) | $(R2R_DIR)
 	$(LD) $(LDFLAGS) NAME $@
+
+$(R2R_DIR):
+	mkdir -p $@
 
 src/check_wifi.obj: src/check_wifi.c
 	$(CC) $(CFLAGS) src/check_wifi.c 


### PR DESCRIPTION
Creates a "Ready 2 Run" directory as `r2r`. Compiles platforms listed in ci.yml and puts the binaries into `r2r/<platform>`. Binaries get attached to PR under Checks tab where they can be easily downloaded for testing.

Should also be expandable for creating releases when we are ready to do that.