### PR TITLE
Disable HIRES for AppleSqueezer

### DIFF
--- a/src/apple2/screen.c
+++ b/src/apple2/screen.c
@@ -169,6 +169,7 @@ void screen_init(void)
     else
     {
       POKE(0xC051,0); // TEXT
+	  POKE(0xC056,0); // LORES (make AppleSqueezer happy)
     }
   #endif
 }


### PR DESCRIPTION
The AppleSqueezer HDMI output isn't up to all Apple II graphics mode details yet.