### PR TITLE
[draft] change system_boot to do the rom switch from ram

### DIFF
--- a/src/msx/system.c
+++ b/src/msx/system.c
@@ -4,6 +4,23 @@ char response[256];
 
 void system_boot(void)
 {
+  // we need to flip the switch to the other rom while not running from rom.
+  // so we put this piece of code in ram at $C000 then we jump to it
+  // to switch and reboot into new rom.
+  // TODO: parameterize the IO_CONTROL port address
+  // C000                          .ORG   C000H   
+  // C000   21 FF BF               LD   hl,$bfff   
+  // C003   36 81                  LD   (hl),$81   
+  // C005   C3 00 00               JP   0   
+
+  unsigned char *code = (unsigned char *)0xC000;
+  code[0] = 0x21; code[1] = 0xFF; code[2] = 0xBF;  // LD hl,$bfff
+  code[3] = 0x36; code[4] = 0x81;                  // LD (hl),$81
+  code[5] = 0xC3; code[6] = 0x00; code[7] = 0x00;  // JP 0
+
+  __asm
+    jp 0xC000
+  __endasm;
   return;
 }
 


### PR DESCRIPTION
We discovered as config called fuji_mount_all() it was then swapping the rom while running from rom and unpredictable things happened next.  We decided that row swap will be done through the IO_CONTROL address of fujiversal so config has to change.
Fujiversal pico code and OpenMSX also needs changes.

this is draft awaiting for corresponding changes in the other repos.
https://github.com/FujiNetWIFI/openMSX/pull/6