### PR TITLE
fix(msx): setting default state/substate value prevents updating

### DIFF
--- a/src/hosts_and_devices.c
+++ b/src/hosts_and_devices.c
@@ -11,7 +11,7 @@
 #include "constants.h"
 #include "globals.h"
 
-HDSubState hd_subState=HD_HOSTS;
+HDSubState hd_subState;
 DeviceSlot deviceSlots[8];
 DeviceSlot temp_deviceSlot;
 bool deviceEnabled[8];

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@
 #include "system.h"
 #include "debug.h"
 
-State state=HOSTS_AND_DEVICES;
+State state;
 bool backToFiles=false;
 bool backFromCopy=false;
 


### PR DESCRIPTION
not sure if it's just z88dk build config and/or if it affects other z88dk targets, but when these have default values I can't seem to update them later, preventing any navigation