### PR TITLE
[MSX] fix: set watermark mode when moving between hosts and devices

### DIFF
--- a/src/msx/screen.c
+++ b/src/msx/screen.c
@@ -362,13 +362,14 @@ void screen_hosts_and_devices_hosts(void)
 {
   show_menu(5, 'b',"_boot", 'e',"_edit", 'd',"_disks", 's',"ba_sic", 'c',"_config");
   clear_status();
+  watermark_visible = true;
   bar_set(0,3,8,selected_host_slot);
-  // bar_set(0,3,8,3);
 }
 
 void screen_hosts_and_devices_devices(void)
 {
   show_menu(5, 'b',"_boot", 'e',"_eject", 'h',"_hosts", 'r'," _r/w", 'c',"_config");
+  watermark_visible = false;
   bar_set(10, 3, 8, selected_device_slot);
 }
 


### PR DESCRIPTION
fixes visual glitch where navigating hosts and devices, after moving off of a row the fujinet logo appeared white as opposed to muted bg color