### PR TITLE
[Idea] Move fuji_bus_call to a higher place in rom so that it's always on the same page as the IO ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,5 +82,8 @@ CFLAGS_EXTRA_C64 = -DUSE_EDITSTRING
 ########################################
 # MSX customization
 
-CFLAGS_EXTRA_MSX =
-LDFLAGS_EXTRA_MSXROM = -pragma-redirect:fputc_cons=fputc_cons_generic -pragma-redirect:CRT_FONT=_font_shifted -create-app -Ca-Isrc/msx/header
+CFLAGS_EXTRA_MSX = -DUSING_FUJINET_LIB
+LDFLAGS_EXTRA_MSXROM = -pragma-redirect:fputc_cons=fputc_cons_generic -pragma-redirect:CRT_FONT=_font_shifted -create-app -Ca-Isrc/msx/header -m
+
+msxrom/r2r-post::
+	python3 src/msx/tools/patch_rom.py $(EXECUTABLE) $(R2R_PD)/$(PRODUCT)_code_fujibus.bin $(R2R_PD)/$(PRODUCT)_fujibus_anchor.bin src/msx/fujibus.s

--- a/src/msx/README.md
+++ b/src/msx/README.md
@@ -1,0 +1,76 @@
+# MSX ROM FujiNet Bus Code Placement
+
+## Overview
+
+This MSX ROM build uses a custom post-processing step to place FujiNet bus communication code at specific memory locations within page2 (0x8000-0xBFFF) of the ROM. This is necessary because the I/O ports at 0xBFFC-0xBFFF must be accessible when the fujinet bus code is running.
+
+## Architecture
+
+### Memory Layout
+
+```
+MSX ROM Memory Map:
+0x4000-0x7FFF : Page 1 your application or fujinet-config this page does not need to
+                be mapped in during the fujinet call
+0x8000-0xBFFF : Page 2 (FujiNet bus code + FujiNet I/O ports + other)
+
+Page 2 Detail:
+0x8000-0xB8FF : Application code (from z88dk linker)
+0xB900-0xBFF8 : FujiNet bus code (code_fujibus section)
+0xBFF9-0xBFFB : Anchor jump (stable entry point)
+0xBFFC-0xBFFF : I/O ports (hardware)
+```
+
+### Why This Design?
+
+1. **Inter-slot calls**: The anchor at 0xBFF9 provides a stable, fixed entry point for inter-slot calls to `fuji_bus_call`. This address never changes, making it safe for code in other ROM slots to call.
+
+2. **Proximity to I/O**: The FujiNet bus code is placed near the end of page2, close to the I/O ports at 0xBFFC-0xBFFF. When page2 is selected, all necessary resources (code and I/O) are available.
+
+3. **Page isolation**: By keeping all FujiNet bus communication code on page2, we ensure it's always accessible when needed without page switching complications.  page 1 is not required during the call.
+
+## Build Process
+
+### 1. Source Files
+
+**`src/msx/fujibus.s`**
+Defines the memory layout for FujiNet bus code:
+```assembly
+SECTION code_fujibus
+ORG 0xB900              ; Start of FujiNet bus code
+
+EXTERN _fuji_bus_call
+SECTION fujibus_anchor
+ORG 0xBFF9              ; Fixed entry point (3 bytes before I/O)
+    jmp _fuji_bus_call  ; Jump to actual implementation
+```
+
+This file is the **single source of truth** for memory addresses. Changing the ORG directives here will automatically update the entire build process.
+
+### 2. Linker Output
+
+The z88dk linker produces separate binary files:
+- `config.rom` - Main ROM image (without FujiNet bus code)
+- `config_code_fujibus.bin` - FujiNet bus code section
+- `config_fujibus_anchor.bin` - 3-byte anchor (JMP instruction)
+
+### 3. Post-Processing
+
+**`src/msx/tools/patch_rom.py`**
+This Python script:
+1. Parses `fujibus.s` to extract ORG addresses
+2. Validates that `code_fujibus` fits in available space
+3. Patches the ROM by inserting:
+   - `code_fujibus` at the address from first ORG directive
+   - `fujibus_anchor` at the address from second ORG directive
+
+The script is invoked automatically by the `msxrom/r2r-post` Makefile target.
+
+## Modifying Memory Layout
+
+To change where FujiNet bus code is placed:
+
+1. Edit `src/msx/fujibus.s` and change the ORG directives
+2. When the fujibus code gets too big the build will fail.  When that happens 
+move code_fujibus ORG lower.
+2. Rebuild - the patch script will automatically use the new addresses

--- a/src/msx/fujibus.s
+++ b/src/msx/fujibus.s
@@ -1,0 +1,7 @@
+SECTION code_fujibus
+ORG 0xB900
+
+EXTERN _fuji_bus_call
+SECTION fujibus_anchor
+ORG 0xBFF9
+    jmp _fuji_bus_call

--- a/src/msx/header/msx_rom_header.asm
+++ b/src/msx/header/msx_rom_header.asm
@@ -1,10 +1,21 @@
 	EXTERN	start
 	EXTERN  callstmt
-
+	SNSMAT	equ 0x0141		; BIOS routine to read a keyboard row
+                      		; Input: A = Row number
+                    		; Output: A = Bit pattern (0 = pressed)
 ; ROM header
 	defm	"AB"
-	defw	start
+	defw	init
 	defw	callstmt                ;CallSTMT handler
 	defw	0                       ;Device handler
 	defw	0                       ;basic
 	defs	6
+
+init:
+	ld a, 6           ; Select Row 6 (contains Shift, Ctrl, Graph, etc.)
+    call SNSMAT       ; Call BIOS
+    bit 0, a          ; Check Bit 0 (the Shift key)
+    jr z, skip_rom    ; If bit is 0 (Z flag set), key is pressed -> skip
+	call	start
+skip_rom:
+	ret

--- a/src/msx/tools/patch_rom.py
+++ b/src/msx/tools/patch_rom.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Patch MSX ROM with FujiNet bus code.
+
+This script patches the config.rom file with:
+1. code_fujibus section at the address specified in fujibus.s
+2. fujibus_anchor at the address specified in fujibus.s
+
+The addresses are read from fujibus.s by parsing ORG directives.
+"""
+
+import sys
+import os
+import re
+
+def parse_fujibus_addresses(fujibus_s_path):
+    """Parse ORG directives from fujibus.s to get memory addresses."""
+    
+    if not os.path.exists(fujibus_s_path):
+        print(f"Error: fujibus.s not found: {fujibus_s_path}", file=sys.stderr)
+        return None, None
+    
+    fujibus_offset = None
+    anchor_offset = None
+    
+    try:
+        with open(fujibus_s_path, 'r') as f:
+            in_code_fujibus = False
+            in_fujibus_anchor = False
+            
+            for line in f:
+                line = line.strip()
+                
+                # Track which section we're in
+                if 'SECTION code_fujibus' in line:
+                    in_code_fujibus = True
+                    in_fujibus_anchor = False
+                elif 'SECTION fujibus_anchor' in line:
+                    in_code_fujibus = False
+                    in_fujibus_anchor = True
+                elif line.startswith('SECTION'):
+                    in_code_fujibus = False
+                    in_fujibus_anchor = False
+                
+                # Parse ORG directives
+                if line.startswith('ORG'):
+                    match = re.match(r'ORG\s+(0x[0-9A-Fa-f]+|[0-9]+)', line)
+                    if match:
+                        addr = int(match.group(1), 0)
+                        if in_code_fujibus and fujibus_offset is None:
+                            fujibus_offset = addr
+                        elif in_fujibus_anchor and anchor_offset is None:
+                            anchor_offset = addr
+    
+    except Exception as e:
+        print(f"Error parsing fujibus.s: {e}", file=sys.stderr)
+        return None, None
+    
+    if fujibus_offset is None:
+        print("Error: Could not find ORG directive in code_fujibus section", file=sys.stderr)
+    if anchor_offset is None:
+        print("Error: Could not find ORG directive in fujibus_anchor section", file=sys.stderr)
+    
+    return fujibus_offset, anchor_offset
+
+def patch_rom(rom_path, fujibus_bin_path, anchor_bin_path, fujibus_offset, anchor_offset):
+    """Patch the ROM file with fujibus code and anchor."""
+    
+    # Constants
+    FUJIBUS_OFFSET = fujibus_offset
+    FUJIBUS_MAX_SIZE = 0xC000 - fujibus_offset - 7 # 4 bytes for IO and 3 bytes for jmp
+    ANCHOR_OFFSET = anchor_offset  # 3 bytes before the IO
+    ROM_START = 0x4000
+    ANCHOR_SIZE = 3
+    
+    # Check if files exist
+    if not os.path.exists(rom_path):
+        print(f"Error: ROM file not found: {rom_path}", file=sys.stderr)
+        return 1
+    
+    if not os.path.exists(fujibus_bin_path):
+        print(f"Error: FujiNet bus binary not found: {fujibus_bin_path}", file=sys.stderr)
+        return 1
+    
+    if not os.path.exists(anchor_bin_path):
+        print(f"Error: Anchor binary not found: {anchor_bin_path}", file=sys.stderr)
+        return 1
+    
+    # Read the ROM file
+    try:
+        with open(rom_path, 'rb') as f:
+            rom = bytearray(f.read())
+    except Exception as e:
+        print(f"Error reading ROM file: {e}", file=sys.stderr)
+        return 1
+    
+    # Read the fujibus binary
+    try:
+        with open(fujibus_bin_path, 'rb') as f:
+            fujibus = f.read()
+    except Exception as e:
+        print(f"Error reading FujiNet bus binary: {e}", file=sys.stderr)
+        return 1
+    
+    # Read the anchor binary
+    try:
+        with open(anchor_bin_path, 'rb') as f:
+            anchor = f.read()
+    except Exception as e:
+        print(f"Error reading anchor binary: {e}", file=sys.stderr)
+        return 1
+    
+    # Validate fujibus size
+    fujibus_size = len(fujibus)
+    if fujibus_size > FUJIBUS_MAX_SIZE:
+        print(f"Error: FujiNet bus code is too large!", file=sys.stderr)
+        print(f"  Size: {fujibus_size} bytes", file=sys.stderr)
+        print(f"  Maximum: {FUJIBUS_MAX_SIZE} bytes", file=sys.stderr)
+        print(f"  Overflow: {fujibus_size - FUJIBUS_MAX_SIZE} bytes", file=sys.stderr)
+        return 1
+    
+    # Validate anchor size
+    if len(anchor) != ANCHOR_SIZE:
+        print(f"Error: Anchor must be exactly {ANCHOR_SIZE} bytes, got {len(anchor)}", file=sys.stderr)
+        return 1
+    
+    # Ensure ROM is large enough
+    min_rom_size = max(FUJIBUS_OFFSET + fujibus_size - ROM_START, ANCHOR_OFFSET + ANCHOR_SIZE - ROM_START)
+    if len(rom) < min_rom_size:
+        print(f"Error: ROM file is too small ({len(rom)} bytes, need at least {min_rom_size})", file=sys.stderr)
+        return 1
+    
+    # Patch the ROM
+    print(f"Patching ROM: {rom_path}")
+    print(f"  FujiNet bus code: {fujibus_size} bytes at offset 0x{FUJIBUS_OFFSET:04X}")
+    print(f"  Anchor: {len(anchor)} bytes at offset 0x{ANCHOR_OFFSET:04X}")
+    
+    rom[(FUJIBUS_OFFSET - ROM_START):(FUJIBUS_OFFSET - ROM_START) + fujibus_size] = fujibus
+    rom[(ANCHOR_OFFSET - ROM_START):(ANCHOR_OFFSET - ROM_START) + ANCHOR_SIZE] = anchor
+    
+    # Write the patched ROM
+    try:
+        with open(rom_path, 'wb') as f:
+            f.write(rom)
+    except Exception as e:
+        print(f"Error writing patched ROM: {e}", file=sys.stderr)
+        return 1
+    
+    print("ROM patched successfully!")
+    return 0
+
+def main():
+    if len(sys.argv) != 5:
+        print("Usage: patch_rom.py <rom_file> <fujibus_bin> <anchor_bin> <fujibus_s>", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Example:", file=sys.stderr)
+        print("  patch_rom.py r2r/msxrom/config.rom r2r/msxrom/config_code_fujibus.bin r2r/msxrom/config_fujibus_anchor.bin src/msx/fujibus.s", file=sys.stderr)
+        return 1
+    
+    rom_path = sys.argv[1]
+    fujibus_bin_path = sys.argv[2]
+    anchor_bin_path = sys.argv[3]
+    fujibus_s_path = sys.argv[4]
+    
+    # Parse addresses from fujibus.s
+    print(f"Reading addresses from: {fujibus_s_path}")
+    fujibus_offset, anchor_offset = parse_fujibus_addresses(fujibus_s_path)
+    
+    if fujibus_offset is None or anchor_offset is None:
+        return 1
+    
+    print(f"Found addresses: fujibus=0x{fujibus_offset:04X}, anchor=0x{anchor_offset:04X}")
+    
+    return patch_rom(rom_path, fujibus_bin_path, anchor_bin_path, fujibus_offset, anchor_offset)
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This MR is just for moving the fuji_bus_call to a higher spot in the rom and to provide a fixed entry point that won't change regardless of the build.
This depends on changes in fujinet-lib-experimental which is linked here: https://github.com/FozzTexx/fujinet-lib-experimental/pull/4

The fujibus.s file(and changes in fujinet-lib-experimental) results in two additional segments config_code_fujibus.bin and config_fujibus_anchor.bin in the r2r/msxrom directory.  Unfortunately these don't automatically get linked/merged into the config.rom so the python script does that.

Next step is to see that the inter slot call works as expected.  Those changes will be in fujinet-lib-experimental.

Note: this also includes the shift key to bypass booting config.  I agree that the choice of shift may not be best.

I have tested that fujinet-config does build and run on msx, but not extensive tests.

FYI fujinet-config already > 16k