### PR TITLE
Fixes to compiling msdos target

### DIFF
--- a/makefiles/fnlib.py
+++ b/makefiles/fnlib.py
@@ -294,7 +294,7 @@ class LibLocator:
 
     self.findLibraryDir(repoDir)
     if not self.MV.FUJINET_LIB_FILE:
-      cmd = ["make", ]
+      cmd = ["make", self.PLATFORM]
       subprocess.run(cmd, cwd=repoDir, check=True, stdout=sys.stderr)
       self.findLibraryDir(repoDir)
 

--- a/src/fuji_typedefs_io.h
+++ b/src/fuji_typedefs_io.h
@@ -1,6 +1,8 @@
 #ifndef FUJI_TYPEDEFS_IO_H
 #define FUJI_TYPEDEFS_IO_H
 
+#include <stddef.h>
+
 // These entries also exist in fujinet-lib, but for systems that are not
 // using fujinet-lib yet, we define them here. This decouples systems
 // that don't use fujinet-lib yet from including fujinet-io.h from it.


### PR DESCRIPTION
Fixes some compile errors for the `msdos` target

When running `make msdos` on the `main` branch I get these errors: 

```sh
src/check_wifi.c(24): Warning! W112: Parameter 1: Pointer truncated
src/check_wifi.c(24): Note! N2003: source conversion type is 'unsigned char __far *'
src/check_wifi.c(24): Note! N2004: target conversion type is 'unsigned char *'
src/check_wifi.c(24): Note! N2002: 'fuji_get_wifi_status' defined in: src/fuji_compat.h(27)
src/check_wifi.c: 36 lines, included 703, 1 warnings, 8 errors
make[1]: *** [/home/bkrein/code/fujinet/fujinet-config/makefiles/common.mk:133: build/msdos/src/check_wifi.o] Error 1
make[1]: Leaving directory '/home/bkrein/code/fujinet/fujinet-config'
make: *** [makefiles/toplevel-rules.mk:22: r2r/msdos/config] Error 2
```

This PR has changes Claude suggested that fix the compile errors.