### PR TITLE
Make fuji_open_directory_filter() compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PLATFORMS += apple2
 PLATFORMS += atari
 PLATFORMS += c64
 PLATFORMS += coco
+
+# Only in lib-experimental currently
 PLATFORMS += msdos
 PLATFORMS += msxrom
 

--- a/src/fuji_compat.c
+++ b/src/fuji_compat.c
@@ -5,7 +5,7 @@
 
 #warning "FIXME - this should be part of fujinet-lib"
 
-bool fuji_open_directory2(uint8_t hs, const char *p, const char *f)
+bool fuji_open_directory2(uint8_t hs, char *p, char *f)
 {
   char *_p = p;
   if (f[0] != 0x00)

--- a/src/fuji_compat.h
+++ b/src/fuji_compat.h
@@ -66,6 +66,7 @@ typedef unsigned short DirectoryPosition;
 #define fuji_update_devices_enabled(de, count)
 
 #define fuji_device_slot_to_device(ds) (ds + FUJI_SLOT_TO_DEV_OFFSET)
+#define fuji_open_directory_filter(hs, path, filter) fuji_open_directory2(hs, path, filter)
 
 #if defined(BUILD_ADAM) || defined(BUILD_RC2014)
 #define FUJI_SLOT_TO_DEV_OFFSET 4

--- a/src/select_file.c
+++ b/src/select_file.c
@@ -77,7 +77,7 @@ unsigned char select_file_display(void)
 
   screen_select_file_display(path, filter);
 
-  if (!fuji_open_directory2(selected_host_slot, path, filter))
+  if (!fuji_open_directory_filter(selected_host_slot, path, filter))
   {
     screen_error("  COULD NOT OPEN DIRECTORY.");
     sf_subState = SF_DONE;
@@ -218,7 +218,6 @@ void select_file_choose(char visibleEntries)
 
 void select_file_link(void)
 {
-  bool result;
   char tnfsHostname[128];
   bar_clear(false);
 


### PR DESCRIPTION
Make fuji_open_directory_filter() compatible with both fujinet-lib and experimental