### PR TITLE
fix mount change and file select scrollback

### DIFF
--- a/src/adam/screen.c
+++ b/src/adam/screen.c
@@ -404,7 +404,7 @@ void screen_select_file_choose(char visibleEntries)
   bool occupied = any_slot_occupied();
 
   screen_should_be_cleared=true;
-  bar_set(2,2,visibleEntries,0); // TODO: Handle previous
+  bar_set(2,2,visibleEntries,prev_page ? visibleEntries-1 : 0);
 
   if (copy_mode==true)
   {

--- a/src/apple2/screen.c
+++ b/src/apple2/screen.c
@@ -674,7 +674,7 @@ void screen_select_file_new_custom(void)
 
 void screen_select_file_choose(char visibleEntries)
 {
-  bar_set(3,2,visibleEntries,0); // TODO: Handle previous
+  bar_set(3,2,visibleEntries,prev_page ? visibleEntries-1 : 0);
   cclearxy(0,STATUS_BAR,120);
   gotoxy(0,STATUS_BAR);
   if (copy_mode == true)

--- a/src/c64/screen.c
+++ b/src/c64/screen.c
@@ -406,7 +406,7 @@ void screen_select_file_new_custom(void)
 
 void screen_select_file_choose(char visibleEntries)
 {
-	bar_set(3, 2, visibleEntries, 0); // TODO: Handle previous
+	bar_set(3, 2, visibleEntries, prev_page ? visibleEntries-1 : 0);
 	cclearxy(0, STATUS_BAR, 120);
 	gotoxy(0, STATUS_BAR);
 	screen_print_menu("RETURN", ":SELECT FILE TO MOUNT\r\n");

--- a/src/coco/screen.c
+++ b/src/coco/screen.c
@@ -323,7 +323,7 @@ void screen_select_file_choose(char visibleEntries)
       printf("%-31s","enter OR break fILTER nEW cOPY");
     }
 
-  bar_set(3,0,visibleEntries,0);
+  bar_set(3,0,visibleEntries,prev_page ? visibleEntries-1 : 0);
 
   if (visibleEntries<10)
     screen_add_shadow(3+visibleEntries,ORANGE);

--- a/src/globals.h
+++ b/src/globals.h
@@ -49,5 +49,6 @@ extern uint8_t copy_host_slot;
 extern bool copy_mode;
 extern bool long_entry_displayed;
 extern uint8_t system_create_type;
+extern bool prev_page;
 
 #endif /* GLOBALS_H */

--- a/src/hosts_and_devices.c
+++ b/src/hosts_and_devices.c
@@ -278,8 +278,11 @@ void hosts_and_devices_done(void)
       textcolor(LIST_VBAR_COLOR); cprintf("%c:", s);
       textcolor(TEXT_COLOR); cprintf("%s", deviceSlots[i].file);
 #endif
-      fuji_mount_host_slot(deviceSlots[i].hostSlot);
-      fuji_mount_disk_image(i, deviceSlots[i].mode);
+      if(!(deviceSlots[i].mode & MODE_MOUNTED)) // skip if disk was already mounted
+      {
+        fuji_mount_host_slot(deviceSlots[i].hostSlot);
+        fuji_mount_disk_image(i, deviceSlots[i].mode);
+      }
     }
   }
 

--- a/src/msdos/globals.h
+++ b/src/msdos/globals.h
@@ -78,6 +78,7 @@ extern bool deviceEnabled[NUM_DEVICE_SLOTS];
 extern bool backToFiles;
 extern bool backFromCopy;
 extern char _visibleEntries;
+extern bool prev_page;
 
 extern unsigned short custom_numSectors;
 extern unsigned short custom_sectorSize;

--- a/src/msdos/screen.c
+++ b/src/msdos/screen.c
@@ -681,7 +681,7 @@ void screen_select_file_display_entry(uint8_t y, const char *e, uint16_t entryTy
  */
 void screen_select_file_choose(char visibleEntries)
 {
-    bar_set(FILES_START_Y,1,visibleEntries,0);
+    bar_set(FILES_START_Y,1,visibleEntries,prev_page ? visibleEntries-1 : 0);
     _visibleEntries = visibleEntries;
 }
 

--- a/src/msx/screen.c
+++ b/src/msx/screen.c
@@ -640,7 +640,7 @@ void screen_select_file_choose(char visibleEntries)
   bool occupied = any_slot_occupied();
 
   screen_should_be_cleared = true;
-  bar_set(1,2,visibleEntries,0); // TODO: Handle previous
+  bar_set(1,2,visibleEntries,prev_page ? visibleEntries-1 : 0);
 
   if (copy_mode == true) {
     show_status("Select destination");

--- a/src/pc6001/screen.c
+++ b/src/pc6001/screen.c
@@ -5,8 +5,8 @@
  * Screen Routines
  */
 
-#include "screen.h"
-#include "globals.h"
+#include "../screen.h"
+#include "../globals.h"
 #include "bar.h"
 #include <conio.h>
 #include <sys/ioctl.h>
@@ -209,7 +209,7 @@ void screen_select_file_choose(char visibleEntries)
 {
   bool slot_1_occupied = deviceSlots[0].file[0] != 0x00;
 
-  bar_set(2,2,visibleEntries,0); // TODO: Handle previous
+  bar_set(2,2,visibleEntries,prev_page ? visibleEntries-1 : 0);
 }
 
 void screen_select_file_filter(void)

--- a/src/pc8801/screen.c
+++ b/src/pc8801/screen.c
@@ -5,8 +5,8 @@
  * Screen Routines
  */
 
-#include "screen.h"
-#include "globals.h"
+#include "../screen.h"
+#include "../globals.h"
 #include "bar.h"
 #include <conio.h>
 #include <sys/ioctl.h>
@@ -208,7 +208,7 @@ void screen_select_file_choose(char visibleEntries)
 {
   bool slot_1_occupied = deviceSlots[0].file[0] != 0x00;
 
-  bar_set(2,2,visibleEntries,0); // TODO: Handle previous
+  bar_set(2,2,visibleEntries,prev_page ? visibleEntries-1 : 0);
 }
 
 void screen_select_file_filter(void)

--- a/src/pmd85/screen.c
+++ b/src/pmd85/screen.c
@@ -610,7 +610,7 @@ void screen_select_file_new_custom(void)
 
 void screen_select_file_choose(char visibleEntries)
 {
-	bar_set(SCR_Y0 + 3, SCR_X0, visibleEntries, 0); // TODO: Handle previous
+	bar_set(SCR_Y0 + 3, SCR_X0, visibleEntries, prev_page ? visibleEntries-1 : 0);
 
 	// screen_clear_status();
 	// gotoxy(SCR_X0 + 8, STATUS_BAR);

--- a/src/rc2014/screen.c
+++ b/src/rc2014/screen.c
@@ -406,7 +406,7 @@ void screen_select_file_new_custom(void)
 
 void screen_select_file_choose(char visibleEntries)
 {
-  bar_set(3,2,visibleEntries,0); // TODO: Handle previous
+  bar_set(3,2,visibleEntries,prev_page ? visibleEntries-1 : 0);
   screen_clear_status();
   screen_gotoxy(0,STATUS_BAR);
   screen_print_menu("RETURN",":SELECT FILE TO MOUNT\r\n");

--- a/src/select_file.c
+++ b/src/select_file.c
@@ -25,6 +25,7 @@ unsigned char entry_size[ENTRIES_PER_PAGE];
 unsigned short entry_timer = ENTRY_TIMER_DUR;
 bool long_entry_displayed = false;
 bool copy_mode = false;
+bool prev_page = false;
 
 extern unsigned char copy_host_slot;
 extern bool backToFiles;
@@ -58,7 +59,7 @@ void select_file_init(void)
 #endif
 
   sf_subState = SF_DISPLAY;
-  quick_boot = dir_eof = false;
+  quick_boot = dir_eof = prev_page = false;
   screen_select_file();
 }
 
@@ -184,6 +185,7 @@ void select_next_page(void)
   pos += ENTRIES_PER_PAGE;
   sf_subState = SF_DISPLAY;
   dir_eof = false;
+  prev_page = false;
 }
 
 void select_prev_page(void)
@@ -192,13 +194,14 @@ void select_prev_page(void)
   pos -= ENTRIES_PER_PAGE;
   sf_subState = SF_DISPLAY;
   dir_eof = false;
+  prev_page = true;
 }
 
 void select_file_filter(void)
 {
   screen_select_file_filter();
   input_line_filter(filter);
-  dir_eof = quick_boot = false;
+  dir_eof = quick_boot = prev_page = false;
   pos = 0;
   sf_subState = SF_DISPLAY;
 }
@@ -261,7 +264,7 @@ void select_file_advance(void)
   fuji_close_directory(); // have to use "e" before calling another io command, otherwise e gets wiped out
 
   pos = 0;
-  dir_eof = quick_boot = false;
+  dir_eof = quick_boot = prev_page = false;
 
   sf_subState = SF_DISPLAY; // and display the result.
 }
@@ -286,7 +289,7 @@ void select_file_devance(void)
   }
 
   pos = 0;
-  dir_eof = quick_boot = false;
+  dir_eof = quick_boot = prev_page = false;
 
   sf_subState = SF_DISPLAY; // And display the result.
 }


### PR DESCRIPTION
fixed if you change a mounted file from read to write, it actually holds now. The reboot was setting it back to read only.
And update the file selector so if you are scrolling back it comes into the bottom of the list for the previous page. While testing the above i kept hitting this and it was going back to the top of the previous page. I added for the other targets, need to check i have not mucked them up.