### PR TITLE
MSX fixes

### DIFF
--- a/src/hosts_and_devices.c
+++ b/src/hosts_and_devices.c
@@ -11,7 +11,7 @@
 #include "constants.h"
 #include "globals.h"
 
-HDSubState hd_subState=HD_HOSTS;
+HDSubState hd_subState;
 DeviceSlot deviceSlots[NUM_DEVICE_SLOTS];
 DeviceSlot temp_deviceSlot;
 bool deviceEnabled[NUM_DEVICE_SLOTS];

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@
 #include "system.h"
 #include "debug.h"
 
-State state=HOSTS_AND_DEVICES;
+State state;
 bool backToFiles=false;
 bool backFromCopy=false;
 

--- a/src/msx/screen.c
+++ b/src/msx/screen.c
@@ -361,13 +361,14 @@ void screen_hosts_and_devices_hosts(void)
 {
   show_menu(5, 'b',"_boot", 'e',"_edit", 'd',"_disks", 's',"ba_sic", 'c',"_config");
   clear_status();
+  watermark_visible = true;
   bar_set(0,3,8,selected_host_slot);
-  // bar_set(0,3,8,3);
 }
 
 void screen_hosts_and_devices_devices(void)
 {
   show_menu(5, 'b',"_boot", 'e',"_eject", 'h',"_hosts", 'r'," _r/w", 'c',"_config");
+  watermark_visible = false;
   bar_set(10, 3, 8, selected_device_slot);
 }
 


### PR DESCRIPTION
Reincorporating latest in `main`. Two fixes for MSX:
1. Issue with setting global state results makes it unchangeable
2. Visual glitches with watermark logo on main config screen