### PR TITLE
Fix remount problem

### DIFF
--- a/src/hosts_and_devices.c
+++ b/src/hosts_and_devices.c
@@ -278,7 +278,9 @@ void hosts_and_devices_done(void)
       textcolor(LIST_VBAR_COLOR); cprintf("%c:", s);
       textcolor(TEXT_COLOR); cprintf("%s", deviceSlots[i].file);
 #endif
+#ifdef BUILD_APPLE2
       if(!(deviceSlots[i].mode & MODE_MOUNTED)) // skip if disk was already mounted
+#endif
       {
         fuji_mount_host_slot(deviceSlots[i].hostSlot);
         fuji_mount_disk_image(i, deviceSlots[i].mode);


### PR DESCRIPTION
Fix problem where disk slots that already have been mounted cannot be mounted again with a different file.

IMPORTANT: Apple2 probably still needs to be revisited on this.

