### PR TITLE
Fix wrong host slot when mounting on ADAM

### DIFF
--- a/src/adam/fuji_io.c
+++ b/src/adam/fuji_io.c
@@ -175,12 +175,20 @@ bool fuji_put_host_slots(HostSlot *h, size_t size)
 #ifndef fuji_put_device_slots
 bool fuji_put_device_slots(DeviceSlot *d, size_t size)
 {
-  unsigned char c[305]={0xF1};
-  unsigned short len = size * sizeof(DeviceSlot);
+  /* The firmware's WRITE DEVICE SLOTS expects all 8 firmware slots
+     (304 bytes) and NAKs anything shorter, leaving EOS retrying the
+     write forever. CONFIG only tracks 4 slots, so fetch the current
+     table and overlay ours. Clobbers response[]. */
+  unsigned char c[305];
+  unsigned char r=0xF2;
 
-  memcpy(&c[1],d,len);
+  io_command_and_response(&r,1);
 
-  eos_write_character_device(FUJI_DEV,&c,len+1);
+  c[0]=0xF1;
+  memcpy(&c[1],response,304);
+  memcpy(&c[1],d,size * sizeof(DeviceSlot));
+
+  eos_write_character_device(FUJI_DEV,&c,sizeof(c));
   csleep(10);
 }
 #endif // fuji_put_device_slots

--- a/src/select_slot.c
+++ b/src/select_slot.c
@@ -132,6 +132,19 @@ void select_slot_done()
 #ifdef BUILD_MSDOS
     pause(6);
 #endif
+
+#ifdef BUILD_ADAM
+    /* The AdamNet SET DEVICE FILENAME (0xE2) wire format carries no
+       host slot or mode; the firmware reuses whatever the slot last
+       held. Write the updated slot table first so the 0xE2 below is
+       applied against the new host slot and mode. */
+    deviceSlots[selected_device_slot].hostSlot=selected_host_slot;
+    deviceSlots[selected_device_slot].mode=mode;
+    memset(deviceSlots[selected_device_slot].file,0,FILE_MAXLEN);
+    strncpy((char *)deviceSlots[selected_device_slot].file,response,FILE_MAXLEN-1);
+    fuji_put_device_slots(&deviceSlots[0], NUM_DEVICE_SLOTS);
+#endif
+
     fuji_set_device_filename(mode, selected_host_slot, selected_device_slot, filename);
 
 #ifdef OBSOLETE


### PR DESCRIPTION
The AdamNet SET DEVICE FULLPATH (0xE2) wire format carries only the device slot and filename; the firmware fills host slot and mode from whatever the slot previously held. The association used to be conveyed by WRITE DEVICE SLOTS (0xF1), but that call was #ifdef OBSOLETE'd in the fujinet-lib migration (84bd1c5), so mounting an image into an occupied slot kept the old host slot.

Restore the 0xF1 write for ADAM in select_slot_done(), ordered before the 0xE2 so the full path is stored against the new host slot.

Also fix fuji_put_device_slots itself: the firmware expects all 8 firmware slots (304 bytes) and NAKs short payloads, leaving EOS retrying the write forever. Read the current table first and overlay the 4 slots CONFIG tracks. This also unbreaks the create-new-disk and slot-eject paths, which call the same function.