### PR TITLE
atari: Add option to boot with High Speed SIO for disks, fuji and network

### DIFF
--- a/src/atari/input.c
+++ b/src/atari/input.c
@@ -274,7 +274,7 @@ HDSubState input_hosts_and_devices_hosts(void)
 
   if (input_handle_console_keys() == 0x03) // "Option" key
   {
-    mount_and_boot();
+    mount_and_boot_selected();
   }
 
   k = input_ucase();
@@ -323,6 +323,9 @@ HDSubState input_hosts_and_devices_hosts(void)
   case 'E':
     hosts_and_devices_edit_host_slot(bar_get() - HOSTS_START_Y);
     return HD_HOSTS;
+  case 'H':
+    hosts_and_devices_hisio_toggle();
+    return HD_HOSTS;
   case 0x7F:
     return HD_DEVICES;
   case 'C':
@@ -361,7 +364,7 @@ HDSubState input_hosts_and_devices_hosts(void)
     }
   case '!':
   case 'B': // Taken from original config. What is that checking for?
-    mount_and_boot();
+    mount_and_boot_selected();
   default:
     return HD_HOSTS;
   }
@@ -375,7 +378,7 @@ HDSubState input_hosts_and_devices_devices(void)
 
   if (input_handle_console_keys() == 0x03)
   {
-    mount_and_boot();
+    mount_and_boot_selected();
   }
 
   k = input_ucase();
@@ -427,6 +430,9 @@ HDSubState input_hosts_and_devices_devices(void)
     // Eject
     hosts_and_devices_eject(bar_get() - DEVICES_START_Y);
     return HD_DEVICES;
+  case 'H':
+    hosts_and_devices_hisio_toggle();
+    return HD_DEVICES;
   case 0x7F:
     return HD_HOSTS;
   case 'R':
@@ -461,7 +467,7 @@ HDSubState input_hosts_and_devices_devices(void)
         return HD_DEVICES;
       }
   case '!':
-    mount_and_boot();
+    mount_and_boot_selected();
   default:
     return HD_DEVICES;
   }
@@ -474,7 +480,7 @@ SFSubState input_select_file_choose(void)
 
   if (input_handle_console_keys() == 0x03)
   {
-    mount_and_boot();
+    mount_and_boot_selected();
   }
 
   k = input_ucase();
@@ -573,7 +579,7 @@ SFSubState input_select_file_choose(void)
     }
   case '!':
   case 'B':
-    mount_and_boot();
+    mount_and_boot_selected();
   default:
     return SF_CHOOSE;
   }
@@ -585,7 +591,7 @@ SSSubState input_select_slot_choose(void)
 //  unsigned char temp[30];
   if (input_handle_console_keys() == 0x03)
   {
-    mount_and_boot();
+    mount_and_boot_selected();
   }
 
   k = input_ucase();

--- a/src/atari/mount_and_boot.c
+++ b/src/atari/mount_and_boot.c
@@ -19,6 +19,33 @@ void mount_and_boot_lobby(void)
     cold_start();
 }
 
+void mount_and_boot_hisio(void)
+{
+    screen_mount_and_boot();
+    set_active_screen(SCREEN_MOUNT_AND_BOOT);
+    screen_clear();
+    screen_puts(3, 0, "MOUNTING HISIO BOOT");
+
+    if (!fuji_set_boot_mode(3))
+    {
+        screen_error("ERROR MOUNTING HISIO BOOT");
+        wait_a_moment();
+        state = HOSTS_AND_DEVICES;
+        return;
+    }
+
+    screen_puts(9, 22, "SUCCESSFUL! BOOTING");
+    cold_start();
+}
+
+void mount_and_boot_selected(void)
+{
+    if (hisio_boot_enabled)
+        mount_and_boot_hisio();
+    else
+        mount_and_boot();
+}
+
 void mount_and_boot(void)
 {
     screen_mount_and_boot();

--- a/src/atari/mount_and_boot.h
+++ b/src/atari/mount_and_boot.h
@@ -6,7 +6,9 @@
 void mount_and_boot(void);
 void mount_and_boot_all_devices(void);
 void mount_and_boot_all_hosts(void);
+void mount_and_boot_hisio(void);
 void mount_and_boot_lobby(void);
+void mount_and_boot_selected(void);
 
 #endif
 #endif

--- a/src/atari/screen.c
+++ b/src/atari/screen.c
@@ -495,6 +495,12 @@ void screen_error(const char *msg)
   screen_puts(0, 24, msg);
 }
 
+void screen_hosts_and_devices_hisio_state(void)
+{
+  screen_clear_line(12);
+  screen_puts(34, 12, hisio_boot_enabled ? CH_INV_H CH_INV_I CH_INV_S CH_INV_I CH_INV_O " " : CH_INV_H "ISIO ");
+}
+
 void screen_hosts_and_devices(HostSlot *, DeviceSlot *, unsigned char *)
 {
   screen_dlist_hosts_and_devices();
@@ -506,6 +512,7 @@ void screen_hosts_and_devices(HostSlot *, DeviceSlot *, unsigned char *)
 
   screen_puts(5, 0, "HOST LIST");
   screen_puts(4, 11, "DRIVE SLOTS");
+  screen_hosts_and_devices_hisio_state();
 
   screen_hosts_and_devices_host_slots(&hostSlots[0]);
 
@@ -540,6 +547,7 @@ void screen_hosts_and_devices_devices(void)
 
   screen_clear_line(11);
   screen_puts(4, 11, "DRIVE SLOTS");
+  screen_hosts_and_devices_hisio_state();
 
   screen_puts(0, 22,
               CH_KEY_1TO8 "Slot" CH_KEY_LABEL_L CH_INV_E CH_KEY_LABEL_R "ject" CH_KEY_LABEL_L CH_INV_C CH_INV_L CH_INV_E CH_INV_A CH_INV_R CH_KEY_LABEL_R "All Slots" CH_KEY_LABEL_L CH_INV_L CH_KEY_LABEL_R "obby");

--- a/src/atari/system.c
+++ b/src/atari/system.c
@@ -4,7 +4,6 @@
 #include <string.h>
 
 static NewDisk newDisk;
-unsigned char wifiEnabled=true;
 char response[256];
 
 void system_boot(void)

--- a/src/check_wifi.c
+++ b/src/check_wifi.c
@@ -9,6 +9,8 @@
 
 extern NetConfig nc;
 
+unsigned char wifiEnabled = true;
+
 void check_wifi(void)
 {
   unsigned char status;

--- a/src/check_wifi.c
+++ b/src/check_wifi.c
@@ -3,7 +3,9 @@
  */
 
 #include "check_wifi.h"
+#include "constants.h"
 #include "globals.h"
+#include "screen.h"
 
 extern NetConfig nc;
 
@@ -15,6 +17,7 @@ void check_wifi(void)
   //
   if ( !fuji_get_wifi_enabled() )
   {
+    wifiEnabled = false;
     state=HOSTS_AND_DEVICES;
 #ifdef COLOR_SETTING_FAILED
     bar_set_color(COLOR_SETTING_FAILED);
@@ -23,8 +26,18 @@ void check_wifi(void)
   else {
     fuji_get_wifi_status(&status);
     if (status == 3)
+    {
+      wifiEnabled = true;
+#ifdef COLOR_SETTING_SUCCESSFUL
+      bar_set_color(COLOR_SETTING_SUCCESSFUL);
+#endif
       state = HOSTS_AND_DEVICES;
+    }
     else {
+      wifiEnabled = false;
+#ifdef COLOR_SETTING_FAILED
+      bar_set_color(COLOR_SETTING_FAILED);
+#endif
       fuji_get_ssid(&nc);
       if (nc.ssid[0] == 0x00)
         state = SET_WIFI;

--- a/src/globals.h
+++ b/src/globals.h
@@ -51,4 +51,8 @@ extern bool long_entry_displayed;
 extern uint8_t system_create_type;
 extern bool prev_page;
 
+#ifdef BUILD_ATARI
+extern bool hisio_boot_enabled;
+#endif /* BUILD_ATARI */
+
 #endif /* GLOBALS_H */

--- a/src/hosts_and_devices.c
+++ b/src/hosts_and_devices.c
@@ -12,6 +12,9 @@
 #include "globals.h"
 
 HDSubState hd_subState;
+#ifdef BUILD_ATARI
+bool hisio_boot_enabled = false;
+#endif /* BUILD_ATARI */
 DeviceSlot deviceSlots[NUM_DEVICE_SLOTS];
 DeviceSlot temp_deviceSlot;
 bool deviceEnabled[NUM_DEVICE_SLOTS];
@@ -224,6 +227,14 @@ void hosts_and_devices_devices_enable_toggle(unsigned char ds)
   bar_update();
 }
 #endif /* BUILD_ADAM */
+
+#ifdef BUILD_ATARI
+void hosts_and_devices_hisio_toggle(void)
+{
+  hisio_boot_enabled = !hisio_boot_enabled;
+  screen_hosts_and_devices_hisio_state();
+}
+#endif /* BUILD_ATARI */
 
 void hosts_and_devices_done(void)
 {

--- a/src/hosts_and_devices.h
+++ b/src/hosts_and_devices.h
@@ -16,5 +16,8 @@ void hosts_and_devices_eject(unsigned char ds);
 #ifdef BUILD_ADAM
 void hosts_and_devices_devices_enable_toggle(unsigned char ds);
 #endif /* BUILD_ADAM */
+#ifdef BUILD_ATARI
+void hosts_and_devices_hisio_toggle(void);
+#endif /* BUILD_ATARI */
 
 #endif /* HOSTS_AND_DEVICES */

--- a/src/screen.h
+++ b/src/screen.h
@@ -60,6 +60,10 @@ void screen_hosts_and_devices_host_slots(HostSlot *h);
 void screen_hosts_and_devices_devices(void);
 void screen_hosts_and_devices_device_slots(uint8_t y, DeviceSlot *d, const bool *e);
 
+#ifdef BUILD_ATARI
+void screen_hosts_and_devices_hisio_state(void);
+#endif /* BUILD_ATARI */
+
 #ifndef BUILD_MSDOS
 void screen_hosts_and_devices_devices_selected(char selected_slot);
 #endif /* !BUILD_MSDOS */

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -11,6 +11,7 @@
 typedef int uint_fast8_t;
 #else /* ! _CMOC_VERSION_ */
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #endif /* _CMOC_VERSION_ */
 


### PR DESCRIPTION
This is updated config for Atari to add HISIO boot option. Works in conjunction with this PR on firmware:

[https://github.com/FujiNetWIFI/fujinet-firmware/pull/1350](https://github.com/FujiNetWIFI/fujinet-firmware/pull/1350)