### PR TITLE
msx: boot to basic disables Config ROM before rebooting

### DIFF
--- a/src/msx/input.c
+++ b/src/msx/input.c
@@ -201,6 +201,7 @@ HDSubState input_hosts_and_devices_hosts(void)
   case 'S':
   case 's':
     show_status("Dropping into BASIC...");
+    boot_to_basic();
     return HD_DONE;
   default:
     return HD_HOSTS;

--- a/src/msx/mount_and_boot.c
+++ b/src/msx/mount_and_boot.c
@@ -4,6 +4,30 @@
 #include "../globals.h"
 #include "../constants.h"
 
+void boot_to_basic(void)
+{
+  // TODO: unify this with the other trampoline in system_boot()
+
+  // we need to flip the switch to the other rom while not running from rom.
+  // so we put this piece of code in ram at $C000 then we jump to it
+  // to switch and reboot into new rom.
+  // TODO: parameterize the IO_CONTROL port address
+  // C000                          .ORG   C000H
+  // C000   21 FF BF               LD   hl,$bfff
+  // C003   36 05                  LD   (hl),$04
+  // C005   C3 00 00               JP   0
+
+  unsigned char *code = (unsigned char *)0xC000;
+  code[0] = 0x21; code[1] = 0xFF; code[2] = 0xBF;  // LD hl,$bfff
+  code[3] = 0x36; code[4] = 0x04;                  // LD (hl),$04
+  code[5] = 0xC3; code[6] = 0x00; code[7] = 0x00;  // JP 0
+
+  __asm
+    jp 0xC000
+  __endasm;
+  return;
+}
+
 void mount_and_boot_lobby(void)
 {
   screen_mount_and_boot();


### PR DESCRIPTION
Makes BASIC menu item work by disabling the Config ROM in the DBC before rebooting

A little gross because it's almost verbatim copy of system_boot, but I want to figure out a way to refactor both with inline assembly vs. hand-done machine code.