### PR TITLE
[apple2] Restart directly from the FujiNet slot

### DIFF
--- a/src/apple2/system.c
+++ b/src/apple2/system.c
@@ -1,14 +1,23 @@
 #include "../system.h"
 #include "sp.h"
 #include "../globals.h"
+#include <string.h>
+#ifndef __ORCAC__
 #include <conio.h>
 #include <apple2.h>
-#include <peekpoke.h> // For the insanity in io_boot()
-#include <string.h>
+#include <peekpoke.h>
+#include <6502.h>
+#endif
 
 static NewDisk newDisk;
 uint8_t system_create_type;
 char response[256];
+
+#ifndef __ORCAC__
+// From FujiNet Lib
+extern uint8_t sp_is_init;
+extern uint8_t sp_dispatch_address[2];
+#endif
 
 void system_boot(void)
 {
@@ -28,14 +37,14 @@ void system_boot(void)
 
   ostype = get_ostype() & 0xF0;
   //clrscr();
-  cprintf("\r\nRESTARTING...");
+  cputs("\r\nRestarting...");
 
   // Wait for fujinet disk ii states to be ready
   for (i = 0; i < 2000; i++)
     {
       if (i % 250 == 0)
         {
-          cprintf(".");
+          cputc('.');
         }
     }
 
@@ -46,9 +55,20 @@ void system_boot(void)
       asm("STA $FFDF");
       asm("JMP $F4EE");  // jmp to A3 reset entry
     }
-  else  // Massive brute force hack that takes advantage of MMU quirk. Thank you xot.
+  else
     {
       POKE(0xC00E,0); // CLRALTCHAR
+
+      if (sp_is_init)
+        {
+          struct regs r;
+
+          cprintf(" from slot %d", sp_dispatch_address[1] & 0x07);
+
+          r.pc = sp_dispatch_address[1] << 8;  // $Cn00
+          _sys(&r);  // No return
+        }
+      // Massive brute force hack that takes advantage of MMU quirk. Thank you xot.
 
       // Make the simulated 6502 RESET result in a cold start.
       // INC $03F4


### PR DESCRIPTION
So far restarting was done by initiating a cold boot. However this approach has the following downsides:
* On the //c, there's an unnecessary  2 second delay (and mechanical wear !) by trying the internal 5.25" drive first.
* On slotted machines, a potential 3rd party mass storage drive in a higher slot is booted instead of the first FujiNet drive although the latter is for sure rather what the user intends after having the FujiNet CONFIG loaded.
* On the ][+ and the unenhanced //e, the A2Pico softSP emulation allows to autostart from the first FujiNet drive after an Apple II reset. But that doesn't work for the simulated reset done so far on CONFIG exit. This makes the whole A2Pico feature rather useless. But when directly booting from the softSP slot on CONFIG exit, the user expereince is the intended one.

There are quite some system setting which are not reset to their defaults by bypassing the cold start. But CONFIG is supposed to be loaded from a system state which is pretty much the default in the first place. One exception is the language card being enabled by the cc65 startup code. But the cc65 _sys() function used to do the direct restart from the FujiNet slot does disable the language card.

If the FujiNet slot couldn't be determined by the FujiNet Lib then the code falls through to the old restart via cold boot.

There may be scenarios where the user intends to boot from the first FujiNet Disk II drive instead of the first FujiNet SmartPort drive. He can do so at any time by manually initiating a cold start either via keyboard or power cycle. Maybe somebody else wants to enhance CONFIG to allow the user to directly boot from the first FujiNet Disk II drive with a special key. The slot number necessary to do so is already determined by diskii_find().